### PR TITLE
Fix README syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
-# CSharpHacks
+# CSharpHacks #
+
 A repository to contain all of the C# Hacks you've ever thought of, anything that makes your coding life easier
 
 In particular, I like nice, generic extension methods that will take wrap up tedious bits of code you need to write all the time.  
 
 Some examples of hacks included already:
 
-###Hacks for Specfic Types
+## Hacks for Specfic Types ##
 
 * IDictionary - transform a dictionary into a look-up function with a default value
 * Integer - TryParse & error check wrapped into a handy extension methods
 
-###Code Structure hacks
+## Code Structure hacks ##
 
-* Map - like a Select in Linq, but applies to the whole array, not just an element at a time
+* Map - like a Select in LINQ, but applies to the whole array, not just an element at a time
 * Alt - an array of functions, which will be tried, one after the other, until one gives a value
 * Fork - process a single data item in multiple ways, then return all  processed values to an aggregator function
 * IfElse - Specify two functions and a condition, based on that condition either the first or second function will be executed


### PR DESCRIPTION
Fix README Syntax

I used this [Markdown lint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) from VS code extension 