### PR TITLE
Add basic NuGet properties in .csproj for NuGet package creation

### DIFF
--- a/CSharpHacks/CSharpHacks/CSharpHacks.csproj
+++ b/CSharpHacks/CSharpHacks/CSharpHacks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <PackageId>CSharpHacks</PackageId>
     <Authors>Simon Painter</Authors>    
     <Description>A repository to contain all of the C# Hacks you've ever thought of, anything that makes your coding life easier </Description>

--- a/CSharpHacks/CSharpHacks/CSharpHacks.csproj
+++ b/CSharpHacks/CSharpHacks/CSharpHacks.csproj
@@ -1,7 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>CSharpHacks</PackageId>
+    <Authors>Simon Painter</Authors>    
+    <Description>A repository to contain all of the C# Hacks you've ever thought of, anything that makes your coding life easier </Description>
+    <PackageVersion>1.0.0</PackageVersion>    
+    <PackageTags>ExtensionMethods</PackageTags>
+    <PackageProjectUrl>https://github.com/madSimonJ/CSharpHacks</PackageProjectUrl>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
I moved the main project to .NET Standard 1.0 (first moved to 2.0, then checked everything works even in such a low version) and added a basic set of NuGet properties in .csproj file - PackageId, Authors, Description (copied from GitHub), tags (actually one, I haven't found another good tag that can be used), GH project url and version.

Then published it to my private experimental feed, included in another project, and everything seems fine.

I think you need to think about versioning this package already - as NuGet versions should be rather immutable later, after release.

Fixes #2 