### PR TITLE
Add UseCulture attribute for decimal tests to work with different culture

### DIFF
--- a/CSharpHacks/CSharpHacks.Tests/StringParseTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/StringParseTests.cs
@@ -21,6 +21,7 @@ namespace CSharpHacks.Tests
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void Valid_double_should_parse_to_double()
         {
             var stringThatIsaDouble = "123.45";
@@ -35,6 +36,7 @@ namespace CSharpHacks.Tests
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void Valid_decimal_should_parse_to_decimal()
         {
             var stringThatIsaDecimal = "123.45";
@@ -49,6 +51,7 @@ namespace CSharpHacks.Tests
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void Valid_float_should_parse_to_float()
         {
             var stringThatIsaDecimal = "123.45";

--- a/CSharpHacks/CSharpHacks.Tests/UseCulture.cs
+++ b/CSharpHacks/CSharpHacks.Tests/UseCulture.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Xunit.Sdk;
+
+namespace CSharpHacks.Tests
+{
+    /// <summary>
+    /// Apply this attribute to your test method to replace the
+    /// <see cref="Thread.CurrentThread" /> <see cref="CultureInfo.CurrentCulture" /> and
+    /// <see cref="CultureInfo.CurrentUICulture" /> with another culture.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class UseCultureAttribute : BeforeAfterTestAttribute
+    {
+        private readonly Lazy<CultureInfo> culture;
+        private readonly Lazy<CultureInfo> uiCulture;
+
+        private CultureInfo originalCulture;
+        private CultureInfo originalUICulture;
+
+        /// <summary>
+        /// Replaces the culture and UI culture of the current thread with
+        /// <paramref name="culture" />
+        /// </summary>
+        /// <param name="culture">The name of the culture.</param>
+        /// <remarks>
+        /// <para>
+        /// This constructor overload uses <paramref name="culture" /> for both
+        /// <see cref="Culture" /> and <see cref="UICulture" />.
+        /// </para>
+        /// </remarks>
+        public UseCultureAttribute(string culture)
+            : this(culture, culture) { }
+
+        /// <summary>
+        /// Replaces the culture and UI culture of the current thread with
+        /// <paramref name="culture" /> and <paramref name="uiCulture" />
+        /// </summary>
+        /// <param name="culture">The name of the culture.</param>
+        /// <param name="uiCulture">The name of the UI culture.</param>
+        public UseCultureAttribute(string culture, string uiCulture)
+        {
+            this.culture = new Lazy<CultureInfo>(() => new CultureInfo(culture, false));
+            this.uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture, false));
+        }
+
+        /// <summary>
+        /// Gets the culture.
+        /// </summary>
+        public CultureInfo Culture { get { return culture.Value; } }
+
+        /// <summary>
+        /// Gets the UI culture.
+        /// </summary>
+        public CultureInfo UICulture { get { return uiCulture.Value; } }
+
+        /// <summary>
+        /// Stores the current <see cref="Thread.CurrentPrincipal" />
+        /// <see cref="CultureInfo.CurrentCulture" /> and <see cref="CultureInfo.CurrentUICulture" />
+        /// and replaces them with the new cultures defined in the constructor.
+        /// </summary>
+        /// <param name="methodUnderTest">The method under test</param>
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            originalCulture = Thread.CurrentThread.CurrentCulture;
+            originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture = Culture;
+            Thread.CurrentThread.CurrentUICulture = UICulture;
+
+            CultureInfo.CurrentCulture.ClearCachedData();
+            CultureInfo.CurrentUICulture.ClearCachedData();
+        }
+
+        /// <summary>
+        /// Restores the original <see cref="CultureInfo.CurrentCulture" /> and
+        /// <see cref="CultureInfo.CurrentUICulture" /> to <see cref="Thread.CurrentPrincipal" />
+        /// </summary>
+        /// <param name="methodUnderTest">The method under test</param>
+        public override void After(MethodInfo methodUnderTest)
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+            Thread.CurrentThread.CurrentUICulture = originalUICulture;
+
+            CultureInfo.CurrentCulture.ClearCachedData();
+            CultureInfo.CurrentUICulture.ClearCachedData();
+        }
+    }
+}


### PR DESCRIPTION
On my machine tests for decimal/float parsing are failing, because of culture which is not using "." as decimal separator.

This PR adds UseCultureAttribute based on xunit.samples (https://github.com/xunit/samples.xunit/blob/master/UseCulture/UseCultureAttribute.cs) and setting culture for these tests to en-US so the tests are not failing by using default culture on the machine.

Using UseCulture is probably easier than preparing tests for different cultures and still ensures that ToDecimal() or ToFloat() extension methods are culture-dependent (as they probably should be).