### PR TITLE
Added Omit, Last and Occurrence method to enumerables

### DIFF
--- a/CSharpHacks/CSharpHacks.Tests/EnumerableExtensionsTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/EnumerableExtensionsTests.cs
@@ -94,5 +94,54 @@ namespace CSharpHacks.Tests
             result.Count.Should().Be(5);
             result.Should().NotContain(x => x.Value == "CCC");
         }
+        
+        [Fact]
+        public void Omit_should_omit_last_x_elements_of_an_enumerable()
+        {
+            int[] expected = {1, 2, 3, 4, 5, 6};
+            int[] test = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+            Assert.Equal(expected, test.Omit(4));
+        }
+
+        [Fact]
+        public void Omit_should_return_empty_enumerable_if_number_is_larger_than_size_of_enumerable()
+        {
+            int[] expected = { };
+            int[] test = {1, 2, 3, 4, 5, 6};
+            Assert.Equal(expected, test.Omit(1000));
+        }
+
+        [Fact]
+        public void Last_should_Return_last_x_elements()
+        {
+            int[] expected = {7, 8, 9};
+            int[] test = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+            Assert.Equal(expected, test.Last(3));
+        }
+
+        [Fact]
+        public void Last_should_return_whole_array_if_number_exceeds_element_size()
+        {
+            int[] expected = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+            int[] test = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+            Assert.Equal(expected, test.Last(1000));
+        }
+
+        [Fact]
+        public void Occurence_should_return_frequency_of_each_element()
+        {
+            string[] test = {"a", "ab", "a", "c", "b", "ab", "a", "hi", "my name", "a", "c"};
+            var expected = new Dictionary<string, int>()
+            {
+                {"a", 4},
+                {"ab", 2},
+                {"b",1},
+                {"c", 2},
+                {"hi", 1},
+                {"my name", 1}
+            };
+            Assert.Equal(expected, test.Occurrence());
+        }
+
     }
 }

--- a/CSharpHacks/CSharpHacks/EnumerableExtensions.cs
+++ b/CSharpHacks/CSharpHacks/EnumerableExtensions.cs
@@ -6,6 +6,34 @@ namespace CSharpHacks
 {
     public static class EnumerableExtensions
     {
+        public static IEnumerable<T> Omit<T>(this IEnumerable<T> x, int n)
+        {
+            return x.Reverse().Skip(n).Reverse();
+        }
+
+        public static IEnumerable<T> Last<T>(this IEnumerable<T> x, int n)
+        {
+            return x.Reverse().Take(n).Reverse();
+        }
+
+        public static IDictionary<T, int> Occurrence<T>(this IEnumerable<T> x)
+        {
+            var frequency = new Dictionary<T, int>();
+            foreach(var  t in x)
+            {
+                if (frequency.ContainsKey(t))
+                {
+                    frequency[t]++;
+                }
+                else
+                {
+                    frequency[t] = 1;
+                }
+            }
+            return frequency;
+        }
+
+        
         public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
             source.ArgumentNotNull(nameof(source));
@@ -73,5 +101,7 @@ namespace CSharpHacks
 
             return argumentValue;
         }
+        
+        
     }
 }


### PR DESCRIPTION
Create Omit, Last and Occurrence function for enumerables.

Omit is like the opposite of LINQ Skip(), it skips the last x elements of the enumerable.
Last is like the opposite of LINQ Take(), it takes the last x elements of the enumerable.
Occurrence() returns a dictionary that counts the amount of occurrence each element in the enumerable.
