### PR TITLE
Add Also and Let object extensions

### DIFF
--- a/CSharpHacks/CSharpHacks.Tests/ObjectTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/ObjectTests.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CSharpHacks.Tests
+{
+    public class ObjectTests
+    {
+        [Fact]
+        public void Let_should_return_converted_object()
+        {
+            var result = 1
+                .Let(x => x.ToString())
+                .Let(x => $"-{x}");
+
+            result.Should().Be("-1");
+        }
+
+        [Fact]
+        public void Also_should_run_additional_code()
+        {
+            var result = ("a" + "b")
+                .Also(TestConsole.WriteLine);
+
+            result.Should().Be("ab");
+            TestConsole.TextWritten.Should().Be("ab");
+        }
+
+        private static class TestConsole
+        {
+            public static string TextWritten = "";
+
+            public static void WriteLine(string text)
+            {
+                TextWritten += text;
+            }
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks/ObjectHacks.cs
+++ b/CSharpHacks/CSharpHacks/ObjectHacks.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace CSharpHacks
+{
+    public static class ObjectHacks
+    {
+        public static T Also<T>(this T @this, Action<T> action)
+        {
+            action(@this);
+            return @this;
+        }
+
+        public static K Let<T, K>(this T @this, Func<T, K> func)
+        {
+            return func(@this);
+        }
+    }
+}


### PR DESCRIPTION
`Also` allows to run additional code via method chaining (eg. print/log the intermediary result)
`Let` is mostly used used for conversion (like a pipe operator in some languages)

Both can be used in conjunction.

Inspired by Kotlin's methods. See https://dzone.com/articles/examining-kotlins-also-apply-let-run-and-with-intentions for more information.