### PR TITLE
Various Additional Extension Methods

### DIFF
--- a/CSharpHacks/CSharpHacks.Tests/AssemblyExtensionsTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/AssemblyExtensionsTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using CSharpHacks.Reflection;
+using CSharpHacks.Tests.Mocks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpHacks.Tests
+{
+    public class AssemblyExtensionsTests
+    {
+        [Fact]
+        public void GetAllTypesImplementingOpenGenericType_ShouldPopulateCorrectly_WhenPassedOpenGenericInterface()
+        {
+            var assembly = GetType().Assembly;
+
+            var actual = assembly
+                .GetAllTypesImplementingOpenGenericType(typeof(IOpenGeneric<>))
+                .ToList();
+
+            actual.Should().HaveCount(4);
+            actual.Should().Contain(typeof(OpenGenericTestClassOfInt));
+            actual.Should().Contain(typeof(OpenGenericTestBaseClassOfT<>));
+            actual.Should().Contain(typeof(OpenGenericDerivedTestClassOfString));
+            actual.Should().Contain(typeof(OpenGenericDerivedTestClassOfBool));
+        }
+
+        [Fact]
+        public void GetAllTypesImplementingOpenGenericType_ShouldPopulateCorrectly_WhenPassedOpenGenericBaseClass()
+        {
+            var assembly = GetType().Assembly;
+
+            var actual = assembly
+                .GetAllTypesImplementingOpenGenericType(typeof(OpenGenericTestBaseClassOfT<>))
+                .ToList();
+
+            actual.Should().HaveCount(2);
+            actual.Should().Contain(typeof(OpenGenericDerivedTestClassOfString));
+            actual.Should().Contain(typeof(OpenGenericDerivedTestClassOfBool));
+        }
+
+        [Fact]
+        public void InstantiateAllTypes_ShouldReturnPopulatedListOfConstructedObjects_WhenAssemblyContainsMatchingTypes()
+        {
+            var assembly = GetType().Assembly;
+
+            var actual = assembly.InstantiateAllTypes<OpenGenericTestBaseClassOfT<string>>().ToList();
+
+            actual.Should().HaveCount(1);
+            actual.Should().AllBeAssignableTo<OpenGenericTestBaseClassOfT<string>>();
+            actual[0].Should().BeOfType<OpenGenericDerivedTestClassOfString>();
+            actual[0].As<OpenGenericDerivedTestClassOfString>().Value.Should().Be("Test Value");
+        }
+
+        [Fact]
+        public void InstantiateAllTypes_ShouldReturnPopulatedListOfConstructedObjects_WhenAssemblyContainsNoMatchingTypes()
+        {
+            var assembly = GetType().Assembly;
+
+            var actual = assembly.InstantiateAllTypes<OpenGenericTestBaseClassOfT<int>>().ToList();
+
+            actual.Should().BeEmpty();
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/CSharpHacks.Tests.csproj
+++ b/CSharpHacks/CSharpHacks.Tests/CSharpHacks.Tests.csproj
@@ -1,16 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-
+    <TargetFramework>net7.0</TargetFramework>
+	  <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpHacks/CSharpHacks.Tests/ColourExtensionsTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/ColourExtensionsTests.cs
@@ -1,0 +1,108 @@
+﻿using System.Drawing;
+using CSharpHacks.Enum;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpHacks.Tests
+{
+    public class ColourExtensionsTests
+    {
+        [Fact]
+        public void UpdateColourChannel_ShouldUpdateColourValue_WhenInvokedUponEachChannel()
+        {
+            var initial = Color.FromArgb(0, 0, 0, 0);
+            var expected = Color.FromArgb(255, 255, 255, 255);
+
+            var updatedRed = initial.UpdateColourChannel(ColourChannel.R, 255);
+            var updatedGreen = updatedRed.UpdateColourChannel(ColourChannel.G, 255);
+            var updatedBlue = updatedGreen.UpdateColourChannel(ColourChannel.B, 255);
+            var actual = updatedBlue.UpdateColourChannel(ColourChannel.A, 255);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void ToNormalisedRgba_ShouldReturnExpectedArray_WhenInvokedOnColorObject()
+        {
+            var initial = Color.FromArgb(alpha: 0, red: 255, green: 0, blue: 255);
+
+            var actual = initial.ToNormalisedRgba();
+
+            actual.Should().ContainInOrder(1d, 0d, 1d, 0d);
+        }
+
+        [Fact]
+        public void ToNormalisedRgba_ShouldReturnExpectedArray_WhenInvokedOnDoubleArray()
+        {
+            var initial = Color.FromArgb(alpha: 0, red: 255, green: 0, blue: 255).ToRgbaDoubleArray();
+
+            var actual = initial.ToNormalisedRgba();
+
+            actual.Should().ContainInOrder(1d, 0d, 1d, 0d);
+        }
+
+        [Fact]
+        public void ToNormalisedArgb_ShouldReturnExpectedArray_WhenInvokedOnColorObject()
+        {
+            var initial = Color.FromArgb(alpha: 0, red: 255, green: 0, blue: 255);
+
+            var actual = initial.ToNormalisedArgb();
+
+            actual.Should().ContainInOrder(0d, 1d, 0d, 1d);
+        }
+
+        [Fact]
+        public void ToNormalisedArgb_ShouldReturnExpectedArray_WhenInvokedOnDoubleArray()
+        {
+            var initial = Color.FromArgb(alpha: 0, red: 255, green: 0, blue: 255).ToArgbDoubleArray();
+
+            var actual = initial.ToNormalisedArgb();
+
+            actual.Should().ContainInOrder(0d, 1d, 0d, 1d);
+        }
+
+        [Fact]
+        public void ToRgbHexString_ShouldReturnCorrectlyFormattedString_WhenInvoked()
+        {
+            var colour = Color.FromArgb(alpha: 255, red: 255, green: 0, blue: 0);
+            const string expected = "#FF0000";
+
+            var actual = colour.ToRgbHexString();
+
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void ToArgbHexString_ShouldReturnCorrectlyFormattedString_WhenInvoked()
+        {
+            var colour = Color.FromArgb(alpha: 255, red: 255, green: 0, blue: 0);
+            const string expected = "#FFFF0000";
+            
+            var actual = colour.ToArgbHexString();
+
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void ToRgbaHexString_ShouldReturnCorrectlyFormattedString_WhenInvoked()
+        {
+            var colour = Color.FromArgb(alpha: 255, red: 255, green: 0, blue: 0);
+            const string expected = "#FF0000FF";
+
+            var actual = colour.ToRgbaHexString();
+
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void ToRgbString_ShouldReturnCorrectlyFormattedString_WhenInvoked()
+        {
+            var colour = Color.FromArgb(alpha: 255, red: 255, green: 0, blue: 0);
+            const string expected = "RGB(255, 0, 0)";
+
+            var actual = colour.ToRgbString();
+
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/CustomAttributeExtensionsTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/CustomAttributeExtensionsTests.cs
@@ -1,0 +1,243 @@
+﻿using CSharpHacks.Reflection;
+using CSharpHacks.Tests.Mocks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpHacks.Tests
+{
+    public class CustomAttributeExtensionsTests
+    {
+        #region HasCustomAttribute
+
+        [Fact]
+        public void HasCustomAttribute_ShouldReturnTrue_WhenTypeHasAttributeOfT()
+        {
+            var sut = typeof(MockAttributedObject);
+
+            var actual = sut.HasCustomAttribute<MockCustomAttributeAttribute>();
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasCustomAttribute_ShouldReturnTrue_WhenAssemblyHasAttributeOfT()
+        {
+            var sut = typeof(MockAttributedObject).Assembly;
+
+            var actual = sut.HasCustomAttribute<MockCustomAttributeAttribute>();
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasCustomAttribute_ShouldReturnTrue_WhenPropertyHasAttributeOfT()
+        {
+            var sut = typeof(MockAttributedObject).GetProperty("Integer");
+
+            var actual = sut.HasCustomAttribute<MockCustomAttributeAttribute>();
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasCustomAttribute_ShouldReturnTrue_WhenFieldHasAttributeOfT()
+        {
+            var sut = typeof(MockAttributedObject).GetField("HelloWorld");
+
+            var actual = sut.HasCustomAttribute<MockCustomAttributeAttribute>();
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasCustomAttribute_ShouldReturnFalse_WhenTypeHasNoAttributeOfT()
+        {
+            var sut = typeof(MockUnattributedObject);
+
+            var actual = sut.HasCustomAttribute<MockCustomAttributeAttribute>();
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void HasCustomAttribute_ShouldReturnFalse_WhenAssemblyHasNoAttributeOfT()
+        {
+            var sut = typeof(CustomAttributeExtensions).Assembly;
+
+            var actual = sut.HasCustomAttribute<MockCustomAttributeAttribute>();
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void HasCustomAttribute_ShouldReturnFalse_WhenPropertyHasNoAttributeOfT()
+        {
+            var sut = typeof(MockUnattributedObject).GetProperty("Integer");
+
+            var actual = sut.HasCustomAttribute<MockCustomAttributeAttribute>();
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void HasCustomAttribute_ShouldReturnFalse_WhenFieldHasNoAttributeOfT()
+        {
+            var sut = typeof(MockUnattributedObject).GetField("HelloWorld");
+
+            var actual = sut.HasCustomAttribute<MockCustomAttributeAttribute>();
+
+            actual.Should().BeFalse();
+        }
+
+        #endregion
+
+        #region TryGetCustomAttribute
+
+        [Fact]
+        public void TryGetCustomAttribute_ShouldReturnTrue_WhenTypeHasAttributeOfT()
+        {
+            var sut = typeof(MockAttributedObject);
+
+            var actual = sut.TryGetCustomAttribute<MockCustomAttributeAttribute>(out var attribute);
+
+            actual.Should().BeTrue();
+            attribute.Should().BeOfType<MockCustomAttributeAttribute>();
+        }
+
+        [Fact]
+        public void TryGetCustomAttribute_ShouldReturnTrue_WhenAssemblyHasAttributeOfT()
+        {
+            var sut = typeof(MockAttributedObject).Assembly;
+
+            var actual = sut.TryGetCustomAttribute<MockCustomAttributeAttribute>(out var attribute);
+
+            actual.Should().BeTrue();
+            attribute.Should().BeOfType<MockCustomAttributeAttribute>();
+        }
+
+        [Fact]
+        public void TryGetCustomAttribute_ShouldReturnTrue_WhenPropertyHasAttributeOfT()
+        {
+            var sut = typeof(MockAttributedObject).GetProperty("Integer");
+
+            var actual = sut.TryGetCustomAttribute<MockCustomAttributeAttribute>(out var attribute);
+
+            actual.Should().BeTrue();
+            attribute.Should().BeOfType<MockCustomAttributeAttribute>();
+        }
+
+        [Fact]
+        public void TryGetCustomAttribute_ShouldReturnTrue_WhenFieldHasAttributeOfT()
+        {
+            var sut = typeof(MockAttributedObject).GetField("HelloWorld");
+
+            var actual = sut.TryGetCustomAttribute<MockCustomAttributeAttribute>(out var attribute);
+
+            actual.Should().BeTrue();
+            attribute.Should().BeOfType<MockCustomAttributeAttribute>();
+        }
+
+        [Fact]
+        public void TryGetCustomAttribute_ShouldReturnFalse_WhenTypeHasNoAttributeOfT()
+        {
+            var sut = typeof(MockUnattributedObject);
+
+            var actual = sut.TryGetCustomAttribute<MockCustomAttributeAttribute>(out var attribute);
+
+            actual.Should().BeFalse();
+            attribute.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryGetCustomAttribute_ShouldReturnFalse_WhenAssemblyHasNoAttributeOfT()
+        {
+            var sut = typeof(CustomAttributeExtensions).Assembly;
+
+            var actual = sut.TryGetCustomAttribute<MockCustomAttributeAttribute>(out var attribute);
+
+            actual.Should().BeFalse();
+            attribute.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryGetCustomAttribute_ShouldReturnFalse_WhenPropertyHasNoAttributeOfT()
+        {
+            var sut = typeof(MockUnattributedObject).GetProperty("Integer");
+
+            var actual = sut.TryGetCustomAttribute<MockCustomAttributeAttribute>(out var attribute);
+
+            actual.Should().BeFalse();
+            attribute.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryGetCustomAttribute_ShouldReturnFalse_WhenFieldHasNoAttributeOfT()
+        {
+            var sut = typeof(MockUnattributedObject).GetField("HelloWorld");
+
+            var actual = sut.TryGetCustomAttribute<MockCustomAttributeAttribute>(out var attribute);
+
+            actual.Should().BeFalse();
+            attribute.Should().BeNull();
+        }
+
+        #endregion
+
+        #region GetDerivedTypesFromAssembly
+
+        [Fact]
+        public void GetDerivedTypesFromAssembly_ShouldReturnPopulatedList_WhenAssemblyContainsTypesWithAttributeOfT()
+        {
+            var attribute = new MockCustomAttributeAttribute();
+
+            var expected = typeof(MockAttributedObject);
+            var assembly = expected.Assembly;
+
+            var actual = attribute.GetDerivedTypesFromAssembly(assembly);
+
+            actual.Should().ContainEquivalentOf((expected, attribute));
+        }
+
+        [Fact]
+        public void GetDerivedTypesFromAssembly_ShouldReturnEmptyList_WhenAssemblyContainsNoTypesWithAttributeOfT()
+        {
+            var attribute = new MockCustomAttributeAttribute();
+
+            var type = typeof(CustomAttributeExtensions);
+            var assembly = type.Assembly;
+
+            var actual = attribute.GetDerivedTypesFromAssembly(assembly);
+
+            actual.Should().BeEmpty();
+        }
+
+        #endregion
+
+        #region GetTypesWithAttribute
+
+        [Fact]
+        public void GetTypesWithAttribute_ShouldReturnPopulatedList_WhenAssemblyContainsTypesWithAttributeOfT()
+        {
+            var attribute = new MockCustomAttributeAttribute();
+            var expected = typeof(MockAttributedObject);
+            var assembly = expected.Assembly;
+
+            var actual = assembly.GetTypesWithAttribute<MockCustomAttributeAttribute>();
+
+            actual.Should().ContainEquivalentOf((expected, attribute));
+        }
+
+        [Fact]
+        public void GetTypesWithAttribute_ShouldReturnEmptyList_WhenAssemblyContainsNoTypesWithAttributeOfT()
+        {
+            var type = typeof(CustomAttributeExtensions);
+            var assembly = type.Assembly;
+
+            var actual = assembly.GetTypesWithAttribute<MockCustomAttributeAttribute>();
+
+            actual.Should().BeEmpty();
+        }
+
+        #endregion
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/EnumExTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/EnumExTests.cs
@@ -1,0 +1,19 @@
+﻿using CSharpHacks.Tests.Mocks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpHacks
+{
+    public class EnumExTests
+    {
+        [Fact]
+        public void Count_ShouldReturnToStringEquivalent_WhenCalledOnEnumWithoutDescriptionAttribute()
+        {
+            const int expected = 4;
+
+            var actual = EnumEx.Count<MockEnum>();
+
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/EnumExtensionsTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/EnumExtensionsTests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using CSharpHacks.Tests.Mocks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpHacks
+{
+    public class EnumExtensionsTests
+    {
+        [Fact]
+        public void GetDescription_ShouldReturnCorrectString_WhenCalledOnEnumWithDescriptionAttribute()
+        {
+            const string expected = "First Value";
+
+            var actual = MockEnum.First.GetDescription();
+
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetDescription_ShouldReturnToStringEquivalent_WhenCalledOnEnumWithoutDescriptionAttribute()
+        {
+            var expected = MockEnum.Fourth.ToString();
+
+            var actual = MockEnum.Fourth.GetDescription();
+
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/EnumerableExtensionsTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/EnumerableExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
@@ -222,6 +223,388 @@ namespace CSharpHacks.Tests
             {
                 result[index].Should().Equal(expected[index]);
             }
+        }
+
+        [Fact]
+        public void Random_ShouldReturnExpectedValue_WhenCalledWithDeterministicRng()
+        {
+            EnumerableExtensions.RandomNumberGenerator = new Random(69);
+
+            var data = Enumerable.Range(0, 100).ToList();
+
+            var actual = new List<int>();
+
+            for (var i = 0; i < 4; i++)
+            {
+                actual.Add(data.Random());
+            }
+
+            actual.Should().ContainInOrder(77, 6, 99, 28);
+        }
+
+        [Fact]
+        public void AddOrUpdate_ShouldAddEntry_WhenItDoesNotAlreadyExistInTheSortedDictionary()
+        {
+            var actual = new SortedDictionary<string, string>();
+            
+            actual.AddOrUpdate("WillAdd", "Hello World!");
+
+            actual.Should().HaveCount(1);
+            actual.Should().Contain("WillAdd", "Hello World!");
+        }
+
+        [Fact]
+        public void AddOrUpdate_ShouldUpdateEntry_WhenItDoesAlreadyExistInTheSortedDictionary()
+        {
+            var actual = new SortedDictionary<string, string>();
+
+            actual.AddOrUpdate("WillUpdate", "¡Hola, mundo!");
+            actual.AddOrUpdate(new KeyValuePair<string, string>("WillUpdate", "Hello World!"));
+
+            actual.Should().HaveCount(1);
+            actual.Should().NotContain("WillUpdate", "¡Hola, mundo!");
+            actual.Should().Contain("WillUpdate", "Hello World!");
+        }
+
+        [Fact]
+        public void AddOrUpdateRange_ShouldAddEntries_WhenTheyDoNotAlreadyExistInTheSortedDictionary()
+        {
+            var actual = new SortedDictionary<string, string>();
+
+            var dataToAdd = new Dictionary<string, string>()
+            {
+                { "English", "Hello, World!" },
+                { "Spanish", "¡Hola, mundo!" },
+                { "German", "Hallo Welt!" },
+                { "Goa'uld", "Chel hol, Tau'ri!" },
+                { "Elder Futhark", "ᚺᛖᛚᛟ ᛗᛁᛞᚷᚨᚱᛞ" },
+            };
+
+            actual.AddOrUpdateRange(dataToAdd);
+            
+            actual.Should().HaveCount(5);
+            actual.Should().Contain(dataToAdd);
+        }
+
+        [Fact]
+        public void AddOrUpdateRange_ShouldUpdateEntries_WhenTheyDoAlreadyExistInTheSortedDictionary()
+        {
+            var actual = new SortedDictionary<string, string>();
+
+            var dataToAdd = new Dictionary<string, string>()
+            {
+                { "English", "This will be updated later." },
+                { "Spanish", "¡Hola, mundo!" },
+                { "German", "Hallo Welt!" },
+            };
+
+            actual.AddOrUpdateRange(dataToAdd);
+
+            var dataToAddOrUpdate = new Dictionary<string, string>()
+            {
+                { "English", "Hello, World!" },
+                { "Goa'uld", "Chel hol, Tau'ri!" },
+                { "Elder Futhark", "ᚺᛖᛚᛟ ᛗᛁᛞᚷᚨᚱᛞ" },
+            };
+
+            actual.AddOrUpdateRange(dataToAddOrUpdate);
+
+            actual.Should().HaveCount(5);
+            actual.Should().NotContain("English", "This will be updated later.");
+            actual.Should().Contain("English", "Hello, World!");
+        }
+
+        [Fact]
+        public void AddOrUpdate_ShouldAddEntry_WhenItDoesNotAlreadyExistInTheDictionary()
+        {
+            var actual = new Dictionary<string, string>();
+
+            actual.AddOrUpdate("WillAdd", "Hello World!");
+
+            actual.Should().HaveCount(1);
+            actual.Should().Contain("WillAdd", "Hello World!");
+        }
+
+        [Fact]
+        public void AddOrUpdate_ShouldUpdateEntry_WhenItDoesAlreadyExistInTheDictionary()
+        {
+            var actual = new Dictionary<string, string>();
+
+            actual.AddOrUpdate("WillUpdate", "¡Hola, mundo!");
+            actual.AddOrUpdate(new KeyValuePair<string, string>("WillUpdate", "Hello World!"));
+
+            actual.Should().HaveCount(1);
+            actual.Should().NotContain("WillUpdate", "¡Hola, mundo!");
+            actual.Should().Contain("WillUpdate", "Hello World!");
+        }
+
+        [Fact]
+        public void AddOrUpdateRange_ShouldAddEntries_WhenTheyDoNotAlreadyExistInTheDictionary()
+        {
+            var actual = new Dictionary<string, string>();
+
+            var dataToAdd = new Dictionary<string, string>()
+            {
+                { "English", "Hello, World!" },
+                { "Spanish", "¡Hola, mundo!" },
+                { "German", "Hallo Welt!" },
+                { "Goa'uld", "Chel hol, Tau'ri!" },
+                { "Elder Futhark", "ᚺᛖᛚᛟ ᛗᛁᛞᚷᚨᚱᛞ" },
+            };
+
+            actual.AddOrUpdateRange(dataToAdd);
+
+            actual.Should().HaveCount(5);
+            actual.Should().Contain(dataToAdd);
+        }
+
+        [Fact]
+        public void AddOrUpdateRange_ShouldUpdateEntries_WhenTheyDoAlreadyExistInTheDictionary()
+        {
+            var actual = new Dictionary<string, string>();
+
+            var dataToAdd = new Dictionary<string, string>()
+            {
+                { "English", "This will be updated later." },
+                { "Spanish", "¡Hola, mundo!" },
+                { "German", "Hallo Welt!" },
+            };
+
+            actual.AddOrUpdateRange(dataToAdd);
+
+            var dataToAddOrUpdate = new Dictionary<string, string>()
+            {
+                { "English", "Hello, World!" },
+                { "Goa'uld", "Chel hol, Tau'ri!" },
+                { "Elder Futhark", "ᚺᛖᛚᛟ ᛗᛁᛞᚷᚨᚱᛞ" },
+            };
+
+            actual.AddOrUpdateRange(dataToAddOrUpdate);
+
+            actual.Should().HaveCount(5);
+            actual.Should().NotContain("English", "This will be updated later.");
+            actual.Should().Contain("English", "Hello, World!");
+        }
+
+        [Fact]
+        public void AddIfNotPresent_ShouldReturnTrue_WhenItemAddedToDictionary()
+        {
+            var actual = new Dictionary<string, string>();
+            
+            var added = actual.AddIfNotPresent("English", "Hello, World!");
+            
+            added.Should().BeTrue();
+            actual.Should().HaveCount(1);
+            actual.Should().Contain("English", "Hello, World!");
+        }
+
+        [Fact]
+        public void AddIfNotPresent_ShouldReturnFalse_WhenItemNotAddedToDictionary()
+        {
+            var actual = new Dictionary<string, string>
+            {
+                { "English", "Hello, World!" }
+            };
+
+            var added = actual.AddIfNotPresent("English", "This will not be updated.");
+
+            added.Should().BeFalse();
+            actual.Should().HaveCount(1);
+            actual.Should().Contain("English", "Hello, World!");
+            actual.Should().NotContain("English", "This will not be updated.");
+        }
+
+        [Fact]
+        public void AddIfNotPresent_ShouldReturnTrue_WhenItemAddedToCollection()
+        {
+            var actual = new List<int>();
+
+            var added = actual.AddIfNotPresent(69);
+
+            added.Should().BeTrue();
+            actual.Should().HaveCount(1);
+            actual.Should().Contain(69);
+        }
+
+        [Fact]
+        public void AddIfNotPresent_ShouldReturnFalse_WhenItemNotAddedToCollection()
+        {
+            var actual = new List<int> { 69 };
+
+            var added = actual.AddIfNotPresent(69);
+
+            added.Should().BeFalse();
+            actual.Should().HaveCount(1);
+            actual.Should().Contain(69);
+        }
+
+        [Fact]
+        public void RemoveIfPresent_ShouldReturnFalse_WhenItemRemovedFromDictionary()
+        {
+            var actual = new Dictionary<string, string>();
+
+            var added = actual.RemoveIfPresent("English");
+
+            added.Should().BeFalse();
+            actual.Should().BeEmpty();
+            actual.Should().NotContainKey("English");
+        }
+
+        [Fact]
+        public void RemoveIfPresent_ShouldReturnTrue_WhenItemNotRemovedFromDictionary()
+        {
+            var actual = new Dictionary<string, string>
+            {
+                { "English", "Hello, World!" }
+            };
+
+            var added = actual.RemoveIfPresent("English");
+
+            added.Should().BeTrue();
+            actual.Should().BeEmpty();
+            actual.Should().NotContain("English", "Hello, World!");
+        }
+
+        [Fact]
+        public void RemoveIfPresent_ShouldReturnFalse_WhenItemRemovedFromCollection()
+        {
+            var actual = new List<int>();
+
+            var added = actual.RemoveIfPresent(69);
+
+            added.Should().BeFalse();
+            actual.Should().BeEmpty();
+            actual.Should().NotContain(69);
+        }
+
+        [Fact]
+        public void RemoveIfPresent_ShouldReturnTrue_WhenItemNotRemovedFromCollection()
+        {
+            var actual = new List<int> { 69 };
+
+            var added = actual.RemoveIfPresent(69);
+
+            added.Should().BeTrue();
+            actual.Should().BeEmpty();
+            actual.Should().NotContain(69);
+        }
+
+        [Fact]
+        public void EnsureExistence_ShouldAddItem_IfInvokedAsTrue()
+        {
+            var actual = Enumerable.Range(0, 100).ToList();
+
+            actual.EnsureExistence(value: 101, shouldExist: true);
+
+            actual.Should().Contain(101);
+        }
+
+        [Fact]
+        public void EnsureExistence_ShouldRemoveItem_IfInvokedAsFalse()
+        {
+            var actual = Enumerable.Range(0, 100).ToList();
+
+            actual.EnsureExistence(value: 69, shouldExist: false);
+
+            actual.Should().NotContain(69);
+        }
+
+        [Fact]
+        public void ContainsAny_ShouldReturnTrue_WhenCollectionDoesContainElement()
+        {
+            var data = Enumerable.Range(0, 100).ToList();
+            var range = new List<int> { 69, 101, 2600 };
+
+            var actual = data.ContainsAny(range);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ContainsAny_ShouldReturnFalse_WhenCollectionDoesNotContainAnyElement()
+        {
+            var data = Enumerable.Range(0, 100).ToList();
+            var range = new List<int> { 690, 101, 2600 };
+
+            var actual = data.ContainsAny(range);
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ContainsAny_ShouldReturnTrue_WhenDictionaryDoesContainElement()
+        {
+            var data = Enumerable.Range(0, 100).ToDictionary(p => p.ToString());
+            var range = new Dictionary<string, int>
+            {
+                { "69", 69 }, 
+                { "101", 101 }, 
+                { "NaN", -1 }
+            };
+
+            var actual = data.ContainsAny(range);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ContainsAny_ShouldReturnFalse_WhenDictionaryDoesNotContainAnyElement()
+        {
+            var data = Enumerable.Range(0, 100).ToDictionary(p => p.ToString());
+            var range = new Dictionary<string, int>
+            {
+                { "690", 690 },
+                { "101", 101 },
+                { "NaN", -1 }
+            };
+
+            var actual = data.ContainsAny(range);
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ContainsAnyKey_ShouldReturnTrue_WhenDictionaryDoesContainElement()
+        {
+            var data = Enumerable.Range(0, 100).ToDictionary(p => p.ToString());
+            var range = new List<string> { "69", "101", "NaN" };
+
+            var actual = data.ContainsAnyKey(range);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ContainsAnyKey_ShouldReturnFalse_WhenDictionaryDoesNotContainAnyElement()
+        {
+            var data = Enumerable.Range(0, 100).ToDictionary(p => p.ToString());
+            var range = new List<string> { "690", "101", "NaN" };
+
+            var actual = data.ContainsAnyKey(range);
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ContainsAnyValue_ShouldReturnTrue_WhenDictionaryDoesContainElement()
+        {
+            var data = Enumerable.Range(0, 100).ToDictionary(p => p.ToString());
+            var range = new List<int> { 69, 101, 2600 };
+
+            var actual = data.ContainsAnyValue(range);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ContainsAnyValue_ShouldReturnFalse_WhenDictionaryDoesNotContainAnyElement()
+        {
+            var data = Enumerable.Range(0, 100).ToDictionary(p => p.ToString());
+            var range = new List<int> { 690, 101, 2600 };
+
+            var actual = data.ContainsAnyValue(range);
+
+            actual.Should().BeFalse();
         }
     }
 }

--- a/CSharpHacks/CSharpHacks.Tests/Helpers/ParseCsvDto.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Helpers/ParseCsvDto.cs
@@ -1,4 +1,4 @@
-namespace CSharpHacks.Tests
+namespace CSharpHacks.Tests.Helpers
 {
     internal class ParseCsvDto
     {

--- a/CSharpHacks/CSharpHacks.Tests/Helpers/UseCultureAttribute.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Helpers/UseCultureAttribute.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Threading;
 using Xunit.Sdk;
 
-namespace CSharpHacks.Tests
+namespace CSharpHacks.Tests.Helpers
 {
     /// <summary>
     /// Apply this attribute to your test method to replace the

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/IMockInterface.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/IMockInterface.cs
@@ -1,0 +1,7 @@
+﻿namespace CSharpHacks.Tests.Mocks
+{
+    public interface IMockInterface
+    {
+        int Integer { get; set; }
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/IOpenGeneric.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/IOpenGeneric.cs
@@ -1,0 +1,4 @@
+﻿namespace CSharpHacks.Tests.Mocks
+{
+    public interface IOpenGeneric<T> { }
+}

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/MockAttributedObject.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/MockAttributedObject.cs
@@ -1,0 +1,18 @@
+﻿namespace CSharpHacks.Tests.Mocks
+{
+    [MockCustomAttribute]
+    public class MockAttributedObject : IMockInterface
+    {
+        [MockCustomAttribute]
+        public MockAttributedObject()
+        {
+            Integer = 69;
+        }
+
+        [MockCustomAttribute]
+        public int Integer { get; set; }
+
+        [MockCustomAttribute]
+        public string HelloWorld = "Hello World!";
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/MockCustomAttributeAttribute.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/MockCustomAttributeAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using CSharpHacks.Tests.Mocks;
+
+[module: MockCustomAttribute]
+[assembly: MockCustomAttribute]
+
+namespace CSharpHacks.Tests.Mocks
+{
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    public class MockCustomAttributeAttribute : Attribute { }
+}

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/MockEmptyObject.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/MockEmptyObject.cs
@@ -1,0 +1,7 @@
+﻿namespace CSharpHacks.Tests.Mocks
+{
+    public class MockEmptyObject
+    {
+
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/MockEnum.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/MockEnum.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel;
+
+namespace CSharpHacks.Tests.Mocks
+{
+    public enum MockEnum
+    {
+        [Description("First Value")]
+        First,
+
+        [Description("Second Value")]
+        Second,
+
+        [Description("Third Value")]
+        Third,
+
+        Fourth
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/MockUnattributedObject.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/MockUnattributedObject.cs
@@ -1,0 +1,14 @@
+﻿namespace CSharpHacks.Tests.Mocks
+{
+    public class MockUnattributedObject : IMockInterface
+    {
+        public MockUnattributedObject()
+        {
+            Integer = 69;
+        }
+        
+        public int Integer { get; set; }
+        
+        public string HelloWorld = "Hello World!";
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/OpenGenericDerivedTestClassOfBool.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/OpenGenericDerivedTestClassOfBool.cs
@@ -1,0 +1,4 @@
+﻿namespace CSharpHacks.Tests.Mocks
+{
+    public class OpenGenericDerivedTestClassOfBool : OpenGenericTestBaseClassOfT<bool> { }
+}

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/OpenGenericDerivedTestClassOfString.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/OpenGenericDerivedTestClassOfString.cs
@@ -1,0 +1,7 @@
+﻿namespace CSharpHacks.Tests.Mocks
+{
+    public class OpenGenericDerivedTestClassOfString : OpenGenericTestBaseClassOfT<string>
+    {
+        public string Value { get; set; } = "Test Value";
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/OpenGenericTestBaseClassOfT.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/OpenGenericTestBaseClassOfT.cs
@@ -1,0 +1,4 @@
+﻿namespace CSharpHacks.Tests.Mocks
+{
+    public class OpenGenericTestBaseClassOfT<T> : IOpenGeneric<T> { }
+}

--- a/CSharpHacks/CSharpHacks.Tests/Mocks/OpenGenericTestClassOfInt.cs
+++ b/CSharpHacks/CSharpHacks.Tests/Mocks/OpenGenericTestClassOfInt.cs
@@ -1,0 +1,4 @@
+﻿namespace CSharpHacks.Tests.Mocks
+{
+    public class OpenGenericTestClassOfInt : IOpenGeneric<int> { }
+}

--- a/CSharpHacks/CSharpHacks.Tests/NumericalExtensionsTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/NumericalExtensionsTests.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedType.Global
+
+namespace CSharpHacks.Tests
+{
+    /// <summary>
+    ///     Provides extension methods for numeric types.
+    /// </summary>
+    public class NumericalExtensionsTests
+    {
+        [Theory]
+        [InlineData(1, 1, false)]
+        [InlineData(1, 2, false)]
+        [InlineData(2, 1, true)]
+
+        [InlineData(1L, 1, false)]
+        [InlineData(1L, 2, false)]
+        [InlineData(2L, 1, true)]
+
+        [InlineData(1f, 1, false)]
+        [InlineData(1f, 2, false)]
+        [InlineData(2f, 1, true)]
+
+        [InlineData(1d, 1, false)]
+        [InlineData(1d, 2, false)]
+        [InlineData(2d, 1, true)]
+        public void IsGreaterThan_ShouldReturnCurrentValue_WhenPassedARangeOfNumericalTypes<T>(T value, T min, bool expected) where T: IComparable
+        {
+            var actual = value.IsGreaterThan(min);
+
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(1, 1, true)]
+        [InlineData(1, 2, false)]
+        [InlineData(2, 1, true)]
+
+        [InlineData(1L, 1, true)]
+        [InlineData(1L, 2, false)]
+        [InlineData(2L, 1, true)]
+
+        [InlineData(1f, 1, true)]
+        [InlineData(1f, 2, false)]
+        [InlineData(2f, 1, true)]
+
+        [InlineData(1d, 1, true)]
+        [InlineData(1d, 2, false)]
+        [InlineData(2d, 1, true)]
+        public void IsGreaterOrEqualToThan_ShouldReturnCurrentValue_WhenPassedARangeOfNumericalTypes<T>(T value, T min, bool expected) where T : IComparable
+        {
+            var actual = value.IsGreaterThanOrEqualTo(min);
+
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(1, 1, false)]
+        [InlineData(1, 2, true)]
+        [InlineData(2, 1, false)]
+
+        [InlineData(1L, 1, false)]
+        [InlineData(1L, 2, true)]
+        [InlineData(2L, 1, false)]
+
+        [InlineData(1f, 1, false)]
+        [InlineData(1f, 2, true)]
+        [InlineData(2f, 1, false)]
+
+        [InlineData(1d, 1, false)]
+        [InlineData(1d, 2, true)]
+        [InlineData(2d, 1, false)]
+        public void IsLessThan_ShouldReturnCurrentValue_WhenPassedARangeOfNumericalTypes<T>(T value, T min, bool expected) where T : IComparable
+        {
+            var actual = value.IsLessThan(min);
+
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(1, 1, true)]
+        [InlineData(1, 2, true)]
+        [InlineData(2, 1, false)]
+
+        [InlineData(1L, 1, true)]
+        [InlineData(1L, 2, true)]
+        [InlineData(2L, 1, false)]
+
+        [InlineData(1f, 1, true)]
+        [InlineData(1f, 2, true)]
+        [InlineData(2f, 1, false)]
+
+        [InlineData(1d, 1, true)]
+        [InlineData(1d, 2, true)]
+        [InlineData(2d, 1, false)]
+        public void IsLessOrEqualToThan_ShouldReturnCurrentValue_WhenPassedARangeOfNumericalTypes<T>(T value, T min, bool expected) where T : IComparable
+        {
+            var actual = value.IsLessThanOrEqualTo(min);
+
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(1, 1, 3, true)]
+        [InlineData(2, 1, 3, true)]
+        [InlineData(3, 1, 3, true)]
+        [InlineData(4, 1, 3, false)]
+
+        [InlineData(1L, 1, 3, true)]
+        [InlineData(2L, 1, 3, true)]
+        [InlineData(3L, 1, 3, true)]
+        [InlineData(4L, 1, 3, false)]
+
+        [InlineData(1f, 1, 3, true)]
+        [InlineData(2f, 1, 3, true)]
+        [InlineData(3f, 1, 3, true)]
+        [InlineData(4f, 1, 3, false)]
+
+        [InlineData(1d, 1, 3, true)]
+        [InlineData(2d, 1, 3, true)]
+        [InlineData(3d, 1, 3, true)]
+        [InlineData(4d, 1, 3, false)]
+        public void IsWithinRange_ShouldReturnCurrentValue_WhenPassedARangeOfNumericalTypes<T>(T value, T min, T max, bool expected) where T : IComparable
+        {
+            var actual = value.IsWithinRange(min, max);
+
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(100, "en", "100")]
+        [InlineData(100, "fr", "100")]
+        [InlineData(100, "de", "100")]
+        [InlineData(1_000, "en", "1,000")]
+        [InlineData(1_000, "fr", "1 000")]
+        [InlineData(1_000, "de", "1.000")]
+        [InlineData(1_000_000, "en", "1,000,000")]
+        [InlineData(1_000_000, "fr", "1 000 000")]
+        [InlineData(1_000_000, "de", "1.000.000")]
+        public void FormatLargeNumber_ShouldFormatCorrectly_WhenPassedARangeOfIntegersInDifferentCultures(int value, string culture, string expected)
+        {
+            var actual = value.FormatLargeNumber(culture);
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(100L, "en", "100")]
+        [InlineData(100L, "fr", "100")]
+        [InlineData(100L, "de", "100")]
+        [InlineData(1_000L, "en", "1,000")]
+        [InlineData(1_000L, "fr", "1 000")]
+        [InlineData(1_000L, "de", "1.000")]
+        [InlineData(1_000_000L, "en", "1,000,000")]
+        [InlineData(1_000_000L, "fr", "1 000 000")]
+        [InlineData(1_000_000L, "de", "1.000.000")]
+        public void FormatLargeNumber_ShouldFormatCorrectly_WhenPassedARangeOfLongsInDifferentCultures(long value, string culture, string expected)
+        {
+            var actual = value.FormatLargeNumber(culture);
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(123.4f, 1, "en", "123.4")]
+        [InlineData(123.4f, 1, "fr", "123,4")]
+        [InlineData(123.4f, 1, "de", "123,4")]
+        [InlineData(1_234.5f, 2, "en", "1,234.50")]
+        [InlineData(1_234.5f, 2, "fr", "1 234,50")]
+        [InlineData(1_234.5f, 2, "de", "1.234,50")]
+        [InlineData(1_234_567.89f, 3, "en", "1,234,567.875")]
+        [InlineData(1_234_567.89f, 3, "fr", "1 234 567,875")]
+        [InlineData(1_234_567.89f, 3, "de", "1.234.567,875")]
+        // KNOWN FRAMEWORK BUG: Rounding float errors explained here: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings
+        public void FormatLargeNumber_ShouldFormatCorrectly_WhenPassedARangeOfFloatsInDifferentCultures(float value, int maxDecimals, string culture, string expected)
+        {
+            var actual = value.FormatLargeNumber(maxDecimals, culture);
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(123.4d, 1, "en", "123.4")]
+        [InlineData(123.4d, 1, "fr", "123,4")]
+        [InlineData(123.4d, 1, "de", "123,4")]
+        [InlineData(1_234.5d, 2, "en", "1,234.50")]
+        [InlineData(1_234.5d, 2, "fr", "1 234,50")]
+        [InlineData(1_234.5d, 2, "de", "1.234,50")]
+        [InlineData(1_234_567.89d, 3, "en", "1,234,567.890")]
+        [InlineData(1_234_567.89d, 3, "fr", "1 234 567,890")]
+        [InlineData(1_234_567.89d, 3, "de", "1.234.567,890")]
+        public void FormatLargeNumber_ShouldFormatCorrectly_WhenPassedARangeOfDoublesInDifferentCultures(double value, int maxDecimals, string culture, string expected)
+        {
+            var actual = value.FormatLargeNumber(maxDecimals, culture);
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks.Tests/ObjectTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/ObjectTests.cs
@@ -27,6 +27,46 @@ namespace CSharpHacks.Tests
             }
         }
 
+        [Fact]
+        public void IsDefaultValue_ShouldReturnTrue_WhenInvokedOnNullReferenceTypes()
+        {
+            string sut = null;
+
+            var actual = sut.IsDefaultValue();
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsDefaultValue_ShouldReturnFalse_WhenInvokedOnNonNullReferenceTypes()
+        {
+            const string sut = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = sut.IsDefaultValue();
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsDefaultValue_ShouldReturnTrue_WhenInvokedOnZeroIntegers()
+        {
+            const int sut = 0;
+
+            var actual = sut.IsDefaultValue();
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsDefaultValue_ShouldReturnFalse_WhenInvokedOnNonZeroIntegers()
+        {
+            const int sut = 1;
+
+            var actual = sut.IsDefaultValue();
+
+            actual.Should().BeFalse();
+        }
+
         #region Dynamic Properties
 
         // ExpandoObject does not play nice with FluentAssertion's "Should()", as it is dynamically typed.

--- a/CSharpHacks/CSharpHacks.Tests/ObjectTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/ObjectTests.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Dynamic;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace CSharpHacks.Tests
 {
@@ -26,5 +26,115 @@ namespace CSharpHacks.Tests
                 TextWritten += text;
             }
         }
+
+        #region Dynamic Properties
+
+        // ExpandoObject does not play nice with FluentAssertion's "Should()", as it is dynamically typed.
+
+        private interface IMockInterface { }
+
+        private class MockObject : IMockInterface { }
+        private class MockObject2 : IMockInterface { }
+
+        [Fact]
+        public void DynamicProperties_ShouldReturnEmptyExpandoObject_WhenFirstCalled()
+        {
+            var sut = new MockObject();
+
+            var actual = sut.DynamicProperties();
+
+            Assert.IsType<ExpandoObject>(actual);
+            Assert.Empty(actual);
+        }
+
+        [Fact]
+        public void DynamicProperties_ShouldRetainData_WhenPassedArguments()
+        {
+            var sut = new MockObject();
+
+            const string expected = "Hello World!";
+            var actual = sut.DynamicProperties();
+
+            sut.DynamicProperties().HelloWorld = expected;
+
+            Assert.NotEmpty(actual);
+            Assert.Equal(actual.HelloWorld, expected);
+        }
+
+        #endregion
+
+        #region Dynamic Casting
+
+        [Fact]
+        public void To_ShouldUnboxToT_WhenAppliedToBoxedObjectOfT()
+        {
+            const int expected = 69;
+            var boxed = (object)expected;
+
+            var actual = boxed.To<int>();
+
+            actual.Should().BeOfType(typeof(int));
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void To_ShouldThrowInvalidCastException_WhenAppliedToIncompatibleObject()
+        {
+            object boxed = 0;
+            boxed
+                .Invoking(b => b.To<float>())
+                .Should()
+                .Throw<InvalidCastException>();
+        }
+
+        [Fact]
+        public void As_ShouldUnboxToT_WhenAppliedToBoxedValueTypeObjectOfT()
+        {
+            const int expected = 69;
+            var boxed = (object)expected;
+
+            var actual = boxed.As<int>();
+
+            actual.Should().BeOfType(typeof(int));
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void As_ShouldUnboxToDefaultOfT_WhenAppliedToBoxedValueTypeObjectNotOfT()
+        {
+            const int initial = 69;
+            const float cast = initial;
+            var boxed = (object)cast;
+
+            var actual = boxed.As<int>();
+
+            actual.Should().BeOfType(typeof(int));
+            actual.Should().Be(default);
+        }
+
+        [Fact]
+        public void As_ShouldUnboxToT_WhenAppliedToBoxedReferenceTypeObjectOfT()
+        {
+            var mockObject = new MockObject();
+            var boxed = (object)mockObject;
+
+            var actual = boxed.As<IMockInterface>();
+
+            actual.Should().NotBeNull();
+            actual.Should().BeAssignableTo<MockObject>();
+        }
+
+        [Fact]
+        public void As_ShouldUnboxToNull_WhenAppliedToBoxedReferenceTypeObjectNotOfT()
+        {
+            var mockObject = new MockObject();
+            var boxed = (object)mockObject;
+            
+            var actual = boxed.As<MockObject2>();
+
+            actual.Should().BeNull();
+        }
+
+        #endregion
     }
 }

--- a/CSharpHacks/CSharpHacks.Tests/StringParseTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/StringParseTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Xunit;
 using FluentAssertions;
 using System.Linq;
+using CSharpHacks.Tests.Helpers;
 
 namespace CSharpHacks.Tests
 {

--- a/CSharpHacks/CSharpHacks.Tests/StringTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/StringTests.cs
@@ -1,5 +1,8 @@
-﻿using FluentAssertions;
+﻿using System.Collections.Generic;
+using FluentAssertions;
 using Xunit;
+
+// ReSharper disable StringLiteralTypo
 
 namespace CSharpHacks.Tests
 {
@@ -24,6 +27,494 @@ namespace CSharpHacks.Tests
         {
             var stringWithMultipleRepetitions = "1.2.3";
             stringWithMultipleRepetitions.ReplaceFirst(",", "").Should().Be("1.2.3");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void IfNullOrEmpty_ShouldReturnInjectedString_WhenInvokedOnNullOrEmptyString(string initial)
+        {
+            const string expected = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.IfNullOrEmpty(expected);
+
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void IfNullOrEmpty_ShouldReturnOriginalString_WhenInvokedOnNonEmptyString()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.IfNullOrEmpty("Sorry, not sorry!");
+
+            actual.Should().Be(initial);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void IfNullOrWhitespace_ShouldReturnInjectedString_WhenInvokedOnNullEmptyOrWhitespaceString(string initial)
+        {
+            const string expected = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.IfNullOrWhitespace(expected);
+
+            actual.Should().Be(expected);   
+        }
+
+        [Fact]
+        public void IfNullOrWhitespace_ShouldReturnOriginalString_WhenInvokedOnNonEmptyString()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.IfNullOrWhitespace("Sorry, not sorry!");
+
+            actual.Should().Be(initial);
+        }
+
+        [Theory]
+        [InlineData(1, "1st")]
+        [InlineData(2, "2nd")]
+        [InlineData(3, "3rd")]
+        [InlineData(4, "4th")]
+
+        [InlineData(11, "11th")]
+        [InlineData(12, "12th")]
+        [InlineData(13, "13th")]
+        [InlineData(14, "14th")]
+
+        [InlineData(21, "21st")]
+        [InlineData(22, "22nd")]
+        [InlineData(23, "23rd")]
+        [InlineData(24, "24th")]
+        public void ToOrdinalNumeral_ShouldReturnExpectedString_WhenInvokedOnARangeOfIntegers(int value, string expected)
+        {
+            var actual = value.ToOrdinalNumeral();
+
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void ContainsLetters_ShouldReturnTrue_WhenInputStringContainsLetters()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.ContainsLetters();
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ContainsLetters_ShouldReturnFalse_WhenInputStringContainsNoLetters()
+        {
+            const string initial = "1234567890";
+
+            var actual = initial.ContainsLetters();
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void OnlyContainsLetters_ShouldReturnFalse_WhenInputStringContainsOnlyLetters()
+        {
+            const string initial = "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz";
+
+            var actual = initial.OnlyContainsLetters();
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void OnlyContainsLetters_ShouldReturnFalse_WhenInputStringContainsNonLetters()
+        {
+            const string initial = "1234567890";
+
+            var actual = initial.OnlyContainsLetters();
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ContainsNumbers_ShouldReturnTrue_WhenInputStringContainsNumbers()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.ContainsNumbers();
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ContainsNumbers_ShouldReturnFalse_WhenInputStringContainsNoNumbers()
+        {
+            const string initial = "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz";
+
+            var actual = initial.ContainsNumbers();
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void OnlyContainsNumbers_ShouldReturnFalse_WhenInputStringContainsOnlyNumbers()
+        {
+            const string initial = "1234567890";
+
+            var actual = initial.OnlyContainsNumbers();
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void OnlyContainsNumbers_ShouldReturnFalse_WhenInputStringContainsNonNumbers()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.OnlyContainsNumbers();
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetLetters_ShouldReturnStringOfOnlyLetters_WhenInputStringContainsAMixOfCharacters()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.GetLetters();
+
+            actual.Should().Be("aHRcHMLydcueWdHViZSjbvdFYgdjkUXcdzlXZhjUQ");
+        }
+
+        [Fact]
+        public void GetDigits_ShouldReturnStringOfOnlyNumbers_WhenInputStringContainsAMixOfCharacters()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.GetDigits();
+
+            actual.Should().Be("0693391520202101");
+        }
+
+        [Fact]
+        public void GetAlphaNumerics_ShouldReturnStringOfOnlyAlphaNumerics_WhenInputStringContainsAMixOfCharacters()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.GetAlphaNumerics();
+
+            actual.Should().Be("aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2gdj1kUXc0dzlXZ1hjUQ");
+        }
+
+        [Fact]
+        public void GetNonAlphaNumerics_ShouldReturnStringOfOnlyNonAlphaNumerics_WhenInputStringContainsAMixOfCharacters()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.GetNonAlphaNumerics();
+
+            actual.Should().Be("/==");
+        }
+
+        [Fact]
+        public void SplitPascalCase_ShouldReturnSentence_WhenInvokedOnPascalCaseString()
+        {
+            const string initial = nameof(StringTests);
+
+            var actual = initial.SplitPascalCase();
+
+            actual.Should().Be("String Tests");
+        }
+
+        [Fact]
+        public void SplitPascalCase_ShouldReturnSentence_WhenInvokedOnPascalCaseStringWithUnderscores()
+        {
+            const string initial = nameof(SplitPascalCase_ShouldReturnSentence_WhenInvokedOnPascalCaseStringWithUnderscores);
+
+            var actual = initial.SplitPascalCase();
+
+            actual.Should().Be("Split Pascal Case Should Return Sentence When Invoked On Pascal Case String With Underscores");
+        }
+
+        [Fact]
+        public void EnsureEndsWith_ShouldAppendSuffix_WhenItDoesNotAlreadyExist()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g";
+            const string suffix = "/dj1kUXc0dzlXZ1hjUQ==";
+            const string expected = initial + suffix;
+
+            var actual = initial.EnsureEndsWith(suffix);
+
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void EnsureEndsWith_ShouldNotAppendSuffix_WhenItDoesAlreadyExist()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+            const string suffix = "/dj1kUXc0dzlXZ1hjUQ==";
+
+            var actual = initial.EnsureEndsWith(suffix);
+
+            actual.Should().Be(initial);
+        }
+
+        [Fact]
+        public void EnsureStartsWith_ShouldAppendSuffix_WhenItDoesNotAlreadyExist()
+        {
+            const string prefix = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g";
+            const string initial = "/dj1kUXc0dzlXZ1hjUQ==";
+            const string expected = prefix + initial;
+
+            var actual = initial.EnsureStartsWith(prefix);
+
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void EnsureStartsWith_ShouldNotAppendSuffix_WhenItDoesAlreadyExist()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+            const string prefix = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g";
+
+            var actual = initial.EnsureStartsWith(prefix);
+
+            actual.Should().Be(initial);
+        }
+
+        [Theory]
+        [InlineData(0, "moose", "meese")]
+        [InlineData(1, "goose", "geese")]
+        [InlineData(2, "mouse", "mice")]
+        public void Pluralise_ShouldReturnCorrectString_WhenPassedARangeOfValues(int value, string singular, string plural)
+        {
+            var expected = value == 1 ? singular : plural;
+
+            var actual = singular.Pluralise(value, plural);
+
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void StartsWithAnyOf_ShouldReturnTrue_WhenStringDoesStartWithARangeOfPrefixes()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.StartsWithAnyOf(range);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void StartsWithAnyOf_ShouldReturnFalse_WhenStringDoesNotStartWithARangeOfPrefixes()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.StartsWithAnyOf(range);
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void StartsWithNoneOf_ShouldReturnFalse_WhenStringDoesStartWithARangeOfPrefixes()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.StartsWithNoneOf(range);
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void StartsWithNoneOf_ShouldReturnTrue_WhenStringDoesNotStartWithARangeOfPrefixes()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.StartsWithNoneOf(range);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void EndsWithAnyOf_ShouldReturnTrue_WhenStringDoesEndWithARangeOfSuffixes()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "/dj1kUXc0dzlXZ1hjUQ==",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.EndsWithAnyOf(range);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void EndsWithAnyOf_ShouldReturnFalse_WhenStringDoesNotEndWithARangeOfSuffixes()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.EndsWithAnyOf(range);
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void EndsWithNoneOf_ShouldReturnFalse_WhenStringDoesEndWithARangeOfSuffixes()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "/dj1kUXc0dzlXZ1hjUQ==",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.EndsWithNoneOf(range);
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void EndsWithNoneOf_ShouldReturnTrue_WhenStringDoesNotEndWithARangeOfSuffixes()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.EndsWithNoneOf(range);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ContainsAnyOf_ShouldReturnTrue_WhenStringDoesContainARangeOfSubStrings()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.ContainsAnyOf(range);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ContainsAnyOf_ShouldReturnFalse_WhenStringDoesNotContainARangeOfSubStrings()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.ContainsAnyOf(range);
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ContainsNoneOf_ShouldReturnFalse_WhenStringDoesContainARangeOfSubStrings()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.ContainsNoneOf(range);
+
+            actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ContainsNoneOf_ShouldReturnTrue_WhenStringDoesNotContainARangeOfSubStrings()
+        {
+            const string initial = "aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==";
+
+            var range = new List<string>
+            {
+                "Never Gonna Give You Up",
+                "Never Gonna Let You Down",
+                "Never Gonna Run Around",
+                "And Desert You"
+            };
+
+            var actual = initial.ContainsNoneOf(range);
+
+            actual.Should().BeTrue();
         }
     }
 }

--- a/CSharpHacks/CSharpHacks.Tests/TaskTests.cs
+++ b/CSharpHacks/CSharpHacks.Tests/TaskTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpHacks.Tests
+{
+    public class TaskTests
+    {
+        [Fact]
+        public async Task OnCompletedSuccessfully_ShouldExecuteAction_WhenTaskCompletesSuccessfully()
+        {
+            var tokenSource = new CancellationTokenSource();
+            tokenSource.CancelAfter(10000);
+            var token = tokenSource.Token;
+
+            var actual = false;
+            
+            await Task.Delay(1000, token)
+                .OnCompletedSuccessfully(() => actual = true);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task OnCompletedSuccessfully_ShouldExecuteFunc_WhenTaskCompletesSuccessfully()
+        {
+            var tokenSource = new CancellationTokenSource();
+            tokenSource.CancelAfter(10000);
+            var token = tokenSource.Token;
+
+            static async Task<bool> ReturnFalse(CancellationToken token)
+            {
+                await Task.Delay(1000, token);
+                return false;
+            }
+
+            var actual = await Task.Run(() => ReturnFalse(token), token)
+                .OnCompletedSuccessfully(state => !state);
+
+            actual.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task OnCompletedSuccessfully_ShouldExecuteConvertingFunc_WhenTaskCompletesSuccessfully()
+        {
+            var tokenSource = new CancellationTokenSource();
+            tokenSource.CancelAfter(10000);
+            var token = tokenSource.Token;
+
+            static async Task<bool> ReturnTrue(CancellationToken token)
+            {
+                await Task.Delay(1000, token);
+                return true;
+            }
+
+            var actual = await Task.Run(() => ReturnTrue(token), token)
+                .OnCompletedSuccessfully(state => state.ToString());
+
+            actual.Should().Be("True");
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks.lutconfig
+++ b/CSharpHacks/CSharpHacks.lutconfig
@@ -1,0 +1,6 @@
+<LUTConfig Version="1.0">
+  <Repository>..\</Repository>
+  <ParallelBuilds>true</ParallelBuilds>
+  <ParallelTestRuns>true</ParallelTestRuns>
+  <TestCaseTimeout>180000</TestCaseTimeout>
+</LUTConfig>

--- a/CSharpHacks/CSharpHacks.sln
+++ b/CSharpHacks/CSharpHacks.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.202
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.32916.344
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpHacks.Tests", "CSharpHacks.Tests\CSharpHacks.Tests.csproj", "{4898FF42-1A8E-4A20-8E09-1372AEC0EDB0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpHacks", "CSharpHacks\CSharpHacks.csproj", "{A87B75E8-277A-4FCC-8F0A-2B7690552867}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpHacks", "CSharpHacks\CSharpHacks.csproj", "{A87B75E8-277A-4FCC-8F0A-2B7690552867}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/CSharpHacks/CSharpHacks/CSharpHacks.csproj
+++ b/CSharpHacks/CSharpHacks/CSharpHacks.csproj
@@ -1,13 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
-    <PackageId>CSharpHacks</PackageId>
-    <Authors>Simon Painter</Authors>    
-    <Description>A repository to contain all of the C# Hacks you've ever thought of, anything that makes your coding life easier </Description>
-    <PackageVersion>1.0.0</PackageVersion>    
-    <PackageTags>ExtensionMethods</PackageTags>
-    <PackageProjectUrl>https://github.com/madSimonJ/CSharpHacks</PackageProjectUrl>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>10</LangVersion>
+		<PackageId>CSharpHacks</PackageId>
+		<Authors>Simon Painter</Authors>
+		<Description>A repository to contain all of the C# Hacks you've ever thought of, anything that makes your coding life easier </Description>
+		<PackageVersion>1.0.0</PackageVersion>
+		<PackageTags>ExtensionMethods</PackageTags>
+		<PackageProjectUrl>https://github.com/madSimonJ/CSharpHacks</PackageProjectUrl>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<InternalsVisibleTo Include="CSharpHacks.Tests" />
+	</ItemGroup>
 
 </Project>

--- a/CSharpHacks/CSharpHacks/ColourExtensions.cs
+++ b/CSharpHacks/CSharpHacks/ColourExtensions.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using CSharpHacks.Enum;
+
+// ReSharper disable CommentTypo
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedType.Global
+// ReSharper disable StringLiteralTypo
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace CSharpHacks
+{
+    /// <summary>
+    ///     Extension Methods for when working with Colours.
+    /// </summary>
+    public static class ColourExtensions
+    {
+        /// <summary>
+        ///     Updates a single colour channel within a <see cref="Color"/>.
+        /// </summary>
+        /// <param name="colour">The colour to change the channel of.</param>
+        /// <param name="channel">The channel to change the value of.</param>
+        /// <param name="value">The value to set.</param>
+        /// <returns>A new instance of <see cref="Color"/>, with the updated values.</returns>
+        public static Color UpdateColourChannel(this Color colour, ColourChannel channel, byte value)
+        {
+            return channel switch
+            {
+                ColourChannel.A => Color.FromArgb(value, colour.R, colour.G, colour.B),
+                ColourChannel.R => Color.FromArgb(colour.A, value, colour.G, colour.B),
+                ColourChannel.G => Color.FromArgb(colour.A, colour.R, value, colour.B),
+                ColourChannel.B => Color.FromArgb(colour.A, colour.R, colour.G, value),
+                _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, null)
+            };
+        }
+
+        /// <summary>
+        ///      Converts a <see cref="Color"/> to an array of doubles, in RGBA order.
+        /// </summary>
+        /// <param name="colour">The colour to convert.</param>
+        /// <returns>A double array, with values set in RGBA order.</returns>
+        public static IEnumerable<double> ToRgbaDoubleArray(this Color colour)
+        {
+            return new double[]
+            {
+                colour.R,
+                colour.G,
+                colour.B,
+                colour.A
+            };
+        }
+
+        /// <summary>
+        ///      Converts a <see cref="Color"/> to an array of doubles, in ARGB order.
+        /// </summary>
+        /// <param name="colour">The colour to convert.</param>
+        /// <returns>A double array, with values set in ARGB order.</returns>
+        public static IEnumerable<double> ToArgbDoubleArray(this Color colour)
+        {
+            return new double[]
+            {
+                colour.A,
+                colour.R,
+                colour.G,
+                colour.B
+            };
+        }
+
+        /// <summary>
+        ///     Normalises the specified colour. That being, it converts each channel value into a <see cref="double"/>, between 0.0 and 1.0, by dividing each value by 255.0.
+        /// </summary>
+        /// <param name="colour">The colour to normalise.</param>
+        /// <returns>A double array, with normalised values set in RGBA order.</returns>
+        public static IEnumerable<double> ToNormalisedRgba(this Color colour)
+        {
+            return new[]
+            {
+                colour.R / 255d,
+                colour.G / 255d,
+                colour.B / 255d,
+                colour.A / 255d
+            };
+        }
+
+        /// <summary>
+        ///     Normalises the specified colour. That being, it converts each channel value into a <see cref="double"/>, between 0.0 and 1.0, by dividing each value by 255.0.
+        /// </summary>
+        /// <param name="colour">The colour to normalise.</param>
+        /// <returns>A double array, with normalised values set in ARGB order.</returns>
+        public static IEnumerable<double> ToNormalisedArgb(this Color colour)
+        {
+            return new[]
+            {
+                colour.A / 255d,
+                colour.R / 255d,
+                colour.G / 255d,
+                colour.B / 255d
+            };
+        }
+
+        /// <summary>
+        ///     Normalises the specified colour. That being, it converts each channel value into a <see cref="double"/>, between 0.0 and 1.0, by dividing each value by 255.0.
+        /// </summary>
+        /// <param name="colour">The colour to normalise.</param>
+        /// <returns>A double array, with normalised values set in RGBA order.</returns>
+        public static IEnumerable<double> ToNormalisedRgba(this IEnumerable<double> colour)
+        {
+            var c = colour.ToArray();
+            return new[]
+            {
+                c[0] / 255d,
+                c[1] / 255d,
+                c[2] / 255d,
+                c[3] / 255d
+            };
+        }
+
+        /// <summary>
+        ///     Normalises the specified colour. That being, it converts each channel value into a <see cref="double"/>, between 0.0 and 1.0, by dividing each value by 255.0.
+        /// </summary>
+        /// <param name="colour">The colour to normalise.</param>
+        /// <returns>A double array, with normalised values set in ARGB order.</returns>
+        public static IEnumerable<double> ToNormalisedArgb(this IEnumerable<double> colour)
+        {
+            var c = colour.ToArray();
+            return new[]
+            {
+                c[0] / 255d,
+                c[1] / 255d,
+                c[2] / 255d,
+                c[3] / 255d
+            };
+        }
+
+        /// <summary>
+        ///     Converts a <see cref="Color"/> to an RGB Hexadecimal string.
+        /// </summary>
+        /// <param name="c">The colour to convert.</param>
+        /// <returns>A hex string, in the format #RRGGBB.</returns>
+        public static string ToRgbHexString(this Color c) => $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+
+        /// <summary>
+        ///     Converts a <see cref="Color"/> to an ARGB Hexadecimal string.
+        /// </summary>
+        /// <param name="c">The colour to convert.</param>
+        /// <returns>A hex string, in the format #AARRGGBB.</returns>
+        public static string ToArgbHexString(this Color c) => $"#{c.A:X2}{c.R:X2}{c.G:X2}{c.B:X2}";
+
+        /// <summary>
+        ///     Converts a <see cref="Color"/> to an RGBA Hexadecimal string.
+        /// </summary>
+        /// <param name="c">The colour to convert.</param>
+        /// <returns>A hex string, in the format #RRGGBBAA.</returns>
+        public static string ToRgbaHexString(this Color c) => $"#{c.R:X2}{c.G:X2}{c.B:X2}{c.A:X2}";
+
+        /// <summary>
+        ///     Converts a <see cref="Color"/> to an RGB() string.
+        /// </summary>
+        /// <param name="c">The colour to convert.</param>
+        /// <returns>A string, in the format RGB(0-255, 0-255, 0-255).</returns>
+        public static string ToRgbString(this Color c) => $"RGB({c.R}, {c.G}, {c.B})";
+    }
+}

--- a/CSharpHacks/CSharpHacks/Enum/ColourChannel.cs
+++ b/CSharpHacks/CSharpHacks/Enum/ColourChannel.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel;
+
+namespace CSharpHacks.Enum
+{
+    /// <summary>
+    ///     Specifies a single colour channel within an ARGB colour.
+    /// </summary>
+    public enum ColourChannel
+    {
+        /// <summary>
+        ///     The Alpha channel.
+        /// </summary>
+        [Description("Alpha")] A,
+
+        /// <summary>
+        ///     The Red channel.
+        /// </summary>
+        [Description("Red")] R,
+
+        /// <summary>
+        ///     The Green channel.
+        /// </summary>
+        [Description("Green")] G,
+
+        /// <summary>
+        ///     The Blue channel.
+        /// </summary>
+        [Description("Blue")] B
+    }
+}

--- a/CSharpHacks/CSharpHacks/EnumEx.cs
+++ b/CSharpHacks/CSharpHacks/EnumEx.cs
@@ -1,0 +1,15 @@
+﻿namespace CSharpHacks
+{
+    public static class EnumEx
+    {
+        /// <summary>
+        ///     Gets the number of values within this enum.
+        /// </summary>
+        /// <typeparam name="T">The type of enum to evaluate.</typeparam>
+        /// <returns>The number of entries within this enumeration.</returns>
+        public static int Count<T>() where T : System.Enum
+        {
+            return typeof(T).GetEnumNames().Length;
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks/EnumExtensions.cs
+++ b/CSharpHacks/CSharpHacks/EnumExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+
+namespace CSharpHacks
+{
+    public static class EnumExtensions
+    {
+        /// <summary>
+        ///     Gets the description for the enum member, decorated with a <see cref="DescriptionAttribute"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>A string representation of the description of the enum member, decorated with a DescriptionAttribute.</returns>
+        public static string GetDescription(this System.Enum value)
+        {
+            var fi = value.GetType().GetField(value.ToString());
+            var attributes = (DescriptionAttribute[])fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
+            return attributes.Length > 0 ? attributes[0].Description : value.ToString();
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks/EnumerableExtensions.cs
+++ b/CSharpHacks/CSharpHacks/EnumerableExtensions.cs
@@ -6,6 +6,247 @@ namespace CSharpHacks
 {
     public static class EnumerableExtensions
     {
+        [ThreadStatic]
+        internal static Random RandomNumberGenerator = new(); // Exposed to test suite.
+
+        /// <summary>
+        ///     Chooses a value, at random, from a list of values.
+        /// </summary>
+        /// <typeparam name="T">The type of values within the collection.</typeparam>
+        /// <param name="collection">The collection.</param>
+        /// <returns>A value, of type <typeparamref name="T"/>, selected at random from the <paramref name="collection"/>.</returns>
+        public static T Random<T>(this IEnumerable<T> collection)
+        {
+            var list  = collection.ToList();
+            var index = RandomNumberGenerator.Next(0, list.Count);
+            return list.ElementAt(index);
+        }
+
+        /// <summary>
+        ///     Adds a range of entries into a sorted dictionary.
+        ///     Includes a work around the fact that keys within Sorted Dictionaries cannot normally be overwritten.
+        /// </summary>
+        /// <param name="dict">The dictionary to add to, or update.</param>
+        /// <param name="range">The range of entries to add, or update.</param>
+        public static void AddOrUpdateRange<TKey, TValue>(this SortedDictionary<TKey, TValue> dict, IDictionary<TKey, TValue> range)
+        {
+            foreach (var record in range) dict.AddOrUpdate(record);
+        }
+
+        /// <summary>
+        ///     Adds a range of entries into a sorted dictionary.
+        ///     Includes a work around the fact that keys within Sorted Dictionaries cannot normally be overwritten.
+        /// </summary>
+        /// <param name="dict">The dictionary to add to, or update.</param>
+        /// <param name="range">The range of entries to add, or update.</param>
+        public static void AddOrUpdateRange<TKey, TValue>(this SortedDictionary<TKey, TValue> dict, IEnumerable<KeyValuePair<TKey, TValue>> range)
+        {
+            foreach (var record in range) dict.AddOrUpdate(record);
+        }
+
+        /// <summary>
+        ///     Adds an entry into a sorted dictionary.
+        ///     Includes a work around the fact that keys within Sorted Dictionaries cannot normally be overwritten.
+        /// </summary>
+        /// <param name="dict">The dictionary to save the syntax list to.</param>
+        /// <param name="record">The key-value pair to add.</param>
+        public static void AddOrUpdate<TKey, TValue>(this SortedDictionary<TKey, TValue> dict, KeyValuePair<TKey, TValue> record)
+        {
+            dict.AddOrUpdate(record.Key, record.Value);
+        }
+
+        /// <summary>
+        ///     Adds an entry into a sorted dictionary.
+        ///     Includes a work around the fact that keys within Sorted Dictionaries cannot normally be overwritten.
+        /// </summary>
+        /// <param name="dict">The dictionary to save the syntax list to.</param>
+        /// <param name="key">The key of the value to add.</param>
+        /// <param name="value">The value to add.</param>
+        public static void AddOrUpdate<TKey, TValue>(this SortedDictionary<TKey, TValue> dict, TKey key, TValue value)
+        {
+            try
+            {
+                dict.Add(key, value);
+            }
+            catch (ArgumentException)
+            {
+                dict.Remove(key);
+                dict.Add(key, value);
+            }
+        }
+
+        /// <summary>
+        ///     Adds an item to the <see cref="IDictionary{TKey,TValue}" />, if it not already present in the collection.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the elements of <paramref name="key" />.</typeparam>
+        /// <typeparam name="TValue">The type of the elements of <paramref name="value" />.</typeparam>
+        /// <param name="collection">The collection to add the item to.</param>
+        /// <param name="key">The key to add.</param>
+        /// <param name="value">The value to add.</param>
+        /// <returns><c>true</c> if the item was added to collection, <c>false</c> otherwise.</returns>
+        public static bool AddIfNotPresent<TKey, TValue>(this IDictionary<TKey, TValue> collection, TKey key, TValue value)
+        {
+            var contains = collection.ContainsKey(key);
+            if (!contains) collection.Add(key, value);
+            return !contains;
+        }
+
+        /// <summary>
+        ///     Adds an item to the <see cref="ICollection{TValue}" />, if it not already present in the collection.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the elements of <paramref name="value" />.</typeparam>
+        /// <param name="collection">The collection to add the item to.</param>
+        /// <param name="value">The value to add.</param>
+        /// <returns><c>true</c> if the item was added to collection, <c>false</c> otherwise.</returns>
+        public static bool AddIfNotPresent<TValue>(this ICollection<TValue> collection, TValue value)
+        {
+            var contains = collection.Contains(value);
+            if (!contains) collection.Add(value);
+            return !contains;
+        }
+
+        /// <summary>
+        ///     Adds an item to the <see cref="IDictionary{TKey,TValue}" />, if it not already present in the collection.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the the key within the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of the value within the dictionary.</typeparam>
+        /// <param name="collection">The collection to add the item to.</param>
+        /// <param name="record">The record to add.</param>
+        /// <returns><c>true</c> if the item was added to collection, <c>false</c> otherwise.</returns>
+        public static void AddOrUpdate<TKey, TValue>(this IDictionary<TKey, TValue> collection, KeyValuePair<TKey, TValue> record)
+        {
+            collection.AddOrUpdate(record.Key, record.Value);
+        }
+
+        /// <summary>
+        ///     Adds an item to the <see cref="IDictionary{TKey,TValue}" />, if it not already present in the collection.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the elements of <paramref name="key" />.</typeparam>
+        /// <typeparam name="TValue">The type of the elements of <paramref name="value" />.</typeparam>
+        /// <param name="collection">The collection to add the item to.</param>
+        /// <param name="key">The key to add.</param>
+        /// <param name="value">The value to add.</param>
+        /// <returns><c>true</c> if the item was added to collection, <c>false</c> otherwise.</returns>
+        public static void AddOrUpdate<TKey, TValue>(this IDictionary<TKey, TValue> collection, TKey key, TValue value)
+        {
+            if (!collection.ContainsKey(key))
+            {
+                collection.Add(key, value);
+                return;
+            }
+            collection[key] = value;
+        }
+
+        /// <summary>
+        ///     Adds an item to the <see cref="IDictionary{TKey,TValue}" />, if it not already present in the collection.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the the key within the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of the value within the dictionary.</typeparam>
+        /// <param name="collection">The collection to add the item to.</param>
+        /// <param name="range">The range of items to add.</param>
+        /// <returns><c>true</c> if the item was added to collection, <c>false</c> otherwise.</returns>
+        public static void AddOrUpdateRange<TKey, TValue>(this IDictionary<TKey, TValue> collection, IDictionary<TKey, TValue> range)
+        {
+            foreach (var record in range) collection.AddOrUpdate(record.Key, record.Value);
+        }
+
+        /// <summary>
+        ///     Adds an item to the <see cref="IDictionary{TKey,TValue}" />, if it not already present in the collection.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the the key within the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of the value within the dictionary.</typeparam>
+        /// <param name="collection">The collection to add the item to.</param>
+        /// <param name="range">The range of items to add.</param>
+        /// <returns><c>true</c> if the item was added to collection, <c>false</c> otherwise.</returns>
+        public static void AddOrUpdateRange<TKey, TValue>(this IDictionary<TKey, TValue> collection, IEnumerable<KeyValuePair<TKey, TValue>> range)
+        {
+            foreach (var record in range) collection.AddOrUpdate(record.Key, record.Value);
+        }
+
+        /// <summary>
+        ///     If the value should exist, and it doesn't, it will be removed from the collection.
+        ///     If the value shouldn't exist, and it does, it will be removed from the collection.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the elements of <paramref name="value" />.</typeparam>
+        /// <param name="collection">The collection to add the item to.</param>
+        /// <param name="value">The value to add.</param>
+        /// <param name="shouldExist">Whether or not the value should exist within the collection.</param>
+        /// <returns><c>true</c> if the item was added to collection, <c>false</c> otherwise.</returns>
+        public static void EnsureExistence<TValue>(this List<TValue> collection, TValue value, bool shouldExist) where TValue : IEquatable<TValue>
+        {
+            collection.RemoveAll(p => p.Equals(value));
+            if (shouldExist) collection.Add(value);
+        }
+
+        /// <summary>
+        ///     Removes an item to the <see cref="ICollection{TItem}" />, if it is already present in the collection.
+        /// </summary>
+        /// <returns><c>true</c> if the item was removed from the collection, <c>false</c> otherwise.</returns>
+        public static bool RemoveIfPresent<TKey, TValue>(this IDictionary<TKey, TValue> collection, TKey key)
+        {
+            var contains = collection.ContainsKey(key);
+            if (contains) collection.Remove(key);
+            return contains;
+        }
+
+        /// <summary>
+        ///     Removes an item to the <see cref="ICollection{TItem}" />, if it is already present in the collection.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the elements of <paramref name="item" />.</typeparam>
+        /// <param name="collection">The collection to remove the item from.</param>
+        /// <param name="item">The item to remove.</param>
+        /// <returns><c>true</c> if the item was removed from the collection, <c>false</c> otherwise.</returns>
+        public static bool RemoveIfPresent<TItem>(this ICollection<TItem> collection, TItem item)
+        {
+            var contains = collection.Contains(item);
+            if (contains) collection.Remove(item);
+            return contains;
+        }
+
+        /// <summary>
+        ///     Determines whether the given collection contains any value within a given list of values.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="source">The source collection.</param>
+        /// <param name="values">The list of values.</param>
+        /// <returns>
+        ///     <c>true</c> if the specified collection contains any of the range of values; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool ContainsAny<TValue>(this IEnumerable<TValue> source, IEnumerable<TValue> values)
+        {
+            return values.Any(source.Contains);
+        }
+
+        /// <summary>
+        ///     Determines whether the given dictionary contains any key within a given list of keys.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key held in the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of the values held in the dictionary.</typeparam>
+        /// <param name="source">The source collection.</param>
+        /// <param name="keys">The list of keys.</param>
+        /// <returns>
+        ///     <c>true</c> if the specified dictionary contains any of the range of keys; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool ContainsAnyKey<TKey, TValue>(this IDictionary<TKey, TValue> source, IEnumerable<TKey> keys)
+        {
+            return source.Keys.ContainsAny(keys);
+        }
+
+        /// <summary>
+        ///     Determines whether the given dictionary contains any values within a given list of values.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key held in the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of the values held in the dictionary.</typeparam>
+        /// <param name="source">The source collection.</param>
+        /// <param name="values">The list of values.</param>
+        /// <returns>
+        ///     <c>true</c> if the specified dictionary contains any of the range of keys; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool ContainsAnyValue<TKey, TValue>(this IDictionary<TKey, TValue> source, IEnumerable<TValue> values)
+        {
+            return source.Values.ContainsAny(values);
+        }
+
         public static IEnumerable<T> Omit<T>(this IEnumerable<T> x, int n)
         {
             return x.Reverse().Skip(n).Reverse();

--- a/CSharpHacks/CSharpHacks/NumericalExtensions.cs
+++ b/CSharpHacks/CSharpHacks/NumericalExtensions.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Globalization;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedType.Global
+
+namespace CSharpHacks
+{
+    /// <summary>
+    ///     Provides extension methods for numeric types.
+    /// </summary>
+    public static class NumericalExtensions
+    {
+        /// <summary>
+        ///     Determines whether a value with within a given inclusive range.
+        /// </summary>
+        /// <param name="val">The value.</param>
+        /// <param name="min">The inclusive minimum value.</param>
+        /// <param name="max">The inclusive maximum value.</param>
+        /// <returns>
+        ///   <c>true</c> if the value is within range of the minimum and maximum values; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsWithinRange<T>(this T val, T min, T max) where T : IComparable
+        {
+            return val.IsGreaterThanOrEqualTo(min) && val.IsLessThanOrEqualTo(max);
+        }
+
+        /// <summary>
+        ///     Determines whether a value is greater than a given minimum value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="min">The exclusive minimum value.</param>
+        /// <returns>
+        ///     <c>true</c> if the value is greater than the given minimum value; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsGreaterThan<T>(this T value, T min) where T : IComparable
+        {
+            return value.CompareTo(min) > 0;
+        }
+
+        /// <summary>
+        ///     Determines whether a value is less than a given maximum value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="max">The exclusive maximum value.</param>
+        /// <returns>
+        ///     <c>true</c> if the value is less than the given maximum value; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsLessThan<T>(this T value, T max) where T : IComparable
+        {
+            return value.CompareTo(max) < 0;
+        }
+
+        /// <summary>
+        ///     Determines whether a value is greater than, or equal to, a given minimum value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="min">The inclusive minimum value.</param>
+        /// <returns>
+        ///     <c>true</c> if the value is greater than the given minimum value; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsGreaterThanOrEqualTo<T>(this T value, T min) where T : IComparable
+        {
+            return value.CompareTo(min) >= 0;
+        }
+
+        /// <summary>
+        ///     Determines whether a value is less than, or equal to, a given maximum value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="max">The inclusive maximum value.</param>
+        /// <returns>
+        ///     <c>true</c> if the value is less than the given maximum value; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsLessThanOrEqualTo<T>(this T value, T max) where T : IComparable
+        {
+            return value.CompareTo(max) <= 0;
+        }
+
+        /// <summary>
+        ///     Formats the number in text form, with numerical group separators, for the current locale, set within <see cref="CultureInfo"/>.
+        /// </summary>
+        /// <param name="number">The number to format.</param>
+        /// <param name="locale">The locale to use to determine separator amounts, and deliminators.</param>
+        /// <returns>Returns a string representation of the number, in human readable form.</returns>
+        public static string FormatLargeNumber(this int number, string locale = "en") 
+            => string.Format(CultureInfo.GetCultureInfo(locale), "{0:#,##0.##}", number);
+
+        /// <summary>
+        ///     Formats the number in text form, with numerical group separators, for the current locale, set within <see cref="CultureInfo"/>.
+        /// </summary>
+        /// <param name="number">The number to format.</param>
+        /// <param name="locale">The locale to use to determine separator amounts, and deliminators.</param>
+        /// <returns>Returns a string representation of the number, in human readable form.</returns>
+        public static string FormatLargeNumber(this long number, string locale = "en") 
+            => string.Format(CultureInfo.GetCultureInfo(locale), "{0:#,##0.##}", number);
+
+        /// <summary>
+        ///     Formats the number in text form, with numerical group separators, for the current locale, set within <see cref="CultureInfo"/>.
+        /// </summary>
+        /// <param name="number">The number to format.</param>
+        /// <param name="locale">The locale to use to determine separator amounts, and deliminators.</param>
+        /// <param name="maxDecimals">The maximum number of decimal places to round the number to.</param>
+        /// <returns>Returns a string representation of the number, in human readable form.</returns>
+        public static string FormatLargeNumber(this float number, int maxDecimals = 2, string locale = "en")
+            => string.Format(CultureInfo.GetCultureInfo(locale), $"{{0:N{maxDecimals}}}", number);
+
+        /// <summary>
+        ///     Formats the number in text form, with numerical group separators, for the current locale, set within <see cref="CultureInfo"/>.
+        /// </summary>
+        /// <param name="number">The number to format.</param>
+        /// <param name="locale">The locale to use to determine separator amounts, and deliminators.</param>
+        /// <param name="maxDecimals">The maximum number of decimal places to round the number to.</param>
+        /// <returns>Returns a string representation of the number, in human readable form.</returns>
+        public static string FormatLargeNumber(this double number, int maxDecimals = 2, string locale = "en")
+            => string.Format(CultureInfo.GetCultureInfo(locale), $"{{0:N{maxDecimals}}}", number);
+    }
+}

--- a/CSharpHacks/CSharpHacks/ObjectHacks.cs
+++ b/CSharpHacks/CSharpHacks/ObjectHacks.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using System.Data.SqlTypes;
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
 using System.Dynamic;
 using System.Runtime.CompilerServices;
 
@@ -7,6 +9,17 @@ namespace CSharpHacks
 {
     public static class ObjectHacks
     {
+        /// <summary>
+        ///     Determines whether the specified object is equal to the default instance of the object.
+        /// </summary>
+        /// <typeparam name="T">The type of object to determine the value of.</typeparam>
+        /// <param name="this">The instance of the object to determine the value of.</param>
+        /// <returns>
+        ///   <c>true</c> if the object is set to the default value; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsDefaultValue<T>(this T @this)
+            => EqualityComparer<T?>.Default.Equals(@this, default);
+
         /// <summary>
         ///     ExtendedData for the <see cref="DynamicProperties"/> extension method.
         /// </summary>

--- a/CSharpHacks/CSharpHacks/ObjectHacks.cs
+++ b/CSharpHacks/CSharpHacks/ObjectHacks.cs
@@ -1,13 +1,54 @@
 ﻿using System;
+using System.Data.SqlTypes;
+using System.Dynamic;
+using System.Runtime.CompilerServices;
 
 namespace CSharpHacks
 {
     public static class ObjectHacks
     {
+        /// <summary>
+        ///     ExtendedData for the <see cref="DynamicProperties"/> extension method.
+        /// </summary>
+        private static readonly ConditionalWeakTable<object, object> ExtendedData = new();
+
         public static T Also<T>(this T @this, Action<T> action)
         {
             action(@this);
             return @this;
         }
+
+        /// <summary>
+        ///     Gets a dynamic collection of properties associated with an object instance, with a lifetime scoped to the lifetime of the object.
+        /// </summary>
+        /// <param name="obj">The object the properties are associated with.</param>
+        /// <returns>A dynamic collection of properties associated with an object instance.</returns>
+        public static dynamic DynamicProperties(this object obj) 
+            => ExtendedData.GetValue(obj, _ => new ExpandoObject());
+
+        /// <summary>
+        ///     Directly casts the object instance to a specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of object to cast to.</typeparam>
+        /// <param name="obj">The instance to cast.</param>
+        /// <returns>An instance of Type <typeparamref name="T" />.</returns>
+        public static T To<T>(this object obj)
+            => Type.GetTypeCode(typeof(T)) is TypeCode.DateTime or TypeCode.DBNull or TypeCode.Empty
+                ? throw new ArgumentOutOfRangeException(nameof(T),
+                    "Objects of this TypeCode cannot be cast to, dynamically.")
+                : (T)obj;
+
+        /// <summary>
+        ///     Safely casts the object instance to a specified type.
+        /// </summary>
+        /// <typeparam name="TFromType">The type of object to cast from.</typeparam>
+        /// <typeparam name="TToType">The type of object to cast to.</typeparam>
+        /// <param name="obj">The instance to cast.</param>
+        /// <returns>An instance of Type <typeparamref name="TToType" />.</returns>
+        public static TToType As<TFromType, TToType>(this TFromType obj) where TToType: class
+            => Type.GetTypeCode(typeof(TToType)) is TypeCode.DateTime or TypeCode.DBNull or TypeCode.Empty
+                ? throw new ArgumentOutOfRangeException(nameof(TToType),
+                    "Objects of this TypeCode cannot be cast to, dynamically.")
+                : obj as TToType;
     }
 }

--- a/CSharpHacks/CSharpHacks/Reflection/AssemblyExtensions.cs
+++ b/CSharpHacks/CSharpHacks/Reflection/AssemblyExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace CSharpHacks.Reflection
+{
+    /// <summary>
+    ///     Extension methods to aid reflecting upon assemblies, and their types.
+    /// </summary>
+    public static class AssemblyExtensions
+    {
+        /// <summary>
+        ///     Gets a collection of all types implementing a specified open generic interface, within a given assembly.
+        /// </summary>
+        /// <param name="assembly">The assembly to scan.</param>
+        /// <param name="openGenericType">Type of the open generic.</param>
+        /// <returns></returns>
+        public static IEnumerable<Type> GetAllTypesImplementingOpenGenericType(this Assembly assembly, Type openGenericType) =>
+            assembly.GetTypes()
+                .SelectMany(types => types.GetInterfaces(), (types, interfaces) => new { Types = types, Interfaces = interfaces })
+                .Select(t => new { TypeWrapper = t, t.Types.BaseType })
+                .Where(t =>
+                    t.BaseType is { IsGenericType: true } &&
+                    openGenericType.IsAssignableFrom(t.BaseType.GetGenericTypeDefinition()) ||
+                    t.TypeWrapper.Interfaces.IsGenericType &&
+                    openGenericType.IsAssignableFrom(t.TypeWrapper.Interfaces.GetGenericTypeDefinition()))
+                .Select(t => t.TypeWrapper.Types);
+
+
+        /// <summary>
+        ///     Scans an assembly for all instantiable classes of a specified type, and forms an array of instances.
+        /// </summary>
+        /// <typeparam name="T">The type of class to find.</typeparam>
+        /// <param name="assembly">The assembly to scan.</param>
+        /// <param name="constructorArgs">The constructor arguments to pass to each instance.</param>
+        /// <returns>An array of instantiated classes of a specified type.</returns>
+        public static IEnumerable<T> InstantiateAllTypes<T>(this Assembly assembly, params object[] constructorArgs)
+            where T : class
+        {
+            var objects = assembly
+                .GetTypes()
+                .Where(myType => myType.IsClass && !myType.IsAbstract && myType.IsSubclassOf(typeof(T)))
+                .Select(type => (T)Activator.CreateInstance(type, constructorArgs))
+                .ToList();
+            objects.Sort();
+
+            return objects;
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks/Reflection/CustomAttributeExtensions.cs
+++ b/CSharpHacks/CSharpHacks/Reflection/CustomAttributeExtensions.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+
+// ReSharper disable UnusedType.Global
+// ReSharper disable UnusedMember.Global
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedParameter.Global
+
+namespace CSharpHacks.Reflection
+{
+    /// <summary>
+    ///     Extension methods to aid working with custom attributes.
+    /// </summary>
+    public static class CustomAttributeExtensions
+    {
+        /// <summary>
+        ///     Determines whether the specified member is decorated with the given custom attribute.
+        /// </summary>
+        /// <typeparam name="T">The type of custom Attribute to check for.</typeparam>
+        /// <param name="member">The member to check.</param>
+        /// <returns><c>true</c> if the specified member is decorated with the given custom attribute; otherwise, <c>false</c>.</returns>
+        public static bool HasCustomAttribute<T>(this MemberInfo member) where T : Attribute
+            => member.GetCustomAttributes().OfType<T>().Any();
+
+        /// <summary>
+        ///     Determines whether the specified <see cref="Assembly"/> is decorated with the given custom attribute.
+        /// </summary>
+        /// <typeparam name="T">The type of custom Attribute to check for.</typeparam>
+        /// <param name="assembly">The assembly to check.</param>
+        /// <returns><c>true</c> if the specified <see cref="Assembly"/> is decorated with the given custom attribute; otherwise, <c>false</c>.</returns>
+        public static bool HasCustomAttribute<T>(this Assembly assembly) where T : Attribute
+            => assembly.GetCustomAttributes().OfType<T>().Any();
+
+        /// <summary>
+        ///     Determines whether the specified <see cref="Type"/> is decorated with the given custom attribute.
+        /// </summary>
+        /// <typeparam name="T">The type of custom Attribute to check for.</typeparam>
+        /// <param name="type">The type to check.</param>
+        /// <returns><c>true</c> if the specified <see cref="Type"/> is decorated with the given custom attribute; otherwise, <c>false</c>.</returns>
+        public static bool HasCustomAttribute<T>(this Type type) where T : Attribute
+            => type.GetCustomAttributes().OfType<T>().Any();
+
+        /// <summary>
+        ///     Determines whether the specified member is decorated with the given custom attribute.
+        /// </summary>
+        /// <typeparam name="T">The type of custom Attribute to check for.</typeparam>
+        /// <param name="member">The member to check.</param>
+        /// <param name="attribute">An instance of the custom Attribute that was found.</param>
+        /// <returns><c>true</c> if the specified member is decorated with the given custom attribute; otherwise, <c>false</c>.</returns>
+        public static bool TryGetCustomAttribute<T>(this MemberInfo member, out T attribute) where T : Attribute
+        {
+            var attributes = member.GetCustomAttributes().OfType<T>().ToList();
+            attribute = attributes.FirstOrDefault();
+            return attributes.Any();
+        }
+
+        /// <summary>
+        ///     Determines whether the specified <see cref="Assembly"/> is decorated with the given custom attribute.
+        /// </summary>
+        /// <typeparam name="T">The type of custom Attribute to check for.</typeparam>
+        /// <param name="assembly">The assembly to check.</param>
+        /// <param name="attribute">An instance of the custom Attribute that was found.</param>
+        /// <returns><c>true</c> if the specified <see cref="Assembly"/> is decorated with the given custom attribute; otherwise, <c>false</c>.</returns>
+        public static bool TryGetCustomAttribute<T>(this Assembly assembly, out T attribute) where T : Attribute
+        {
+            var attributes = assembly.GetCustomAttributes().OfType<T>().ToList();
+            attribute = attributes.FirstOrDefault();
+            return attributes.Any();
+        }
+
+        /// <summary>
+        ///     Determines whether the specified <see cref="Type"/> is decorated with the given custom attribute.
+        /// </summary>
+        /// <typeparam name="T">The type of custom Attribute to check for.</typeparam>
+        /// <param name="type">The type to check.</param>
+        /// <param name="attribute">An instance of the custom Attribute that was found.</param>
+        /// <returns><c>true</c> if the specified <see cref="Type"/> is decorated with the given custom attribute; otherwise, <c>false</c>.</returns>
+        public static bool TryGetCustomAttribute<T>(this Type type, out T attribute) where T : Attribute
+        {
+            var attributes = type.GetCustomAttributes().OfType<T>().ToList();
+            attribute = attributes.FirstOrDefault();
+            return attributes.Any();
+        }
+
+        /// <summary>
+        ///     Gets the derived types of a specified Attribute, within a given assembly.
+        /// </summary>
+        /// <typeparam name="T">The type of class level attribute to scan for.</typeparam>
+        /// <param name="attribute">The attribute to scan for.</param>
+        /// <param name="assembly">The assembly to scan.</param>
+        /// <returns>Returns an array of Types that are decorated with the specified class level attribute.</returns>
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Extension Method")]
+        public static IEnumerable<(Type Type, T Attribute)> GetDerivedTypesFromAssembly<T>(this T attribute, Assembly assembly) where T : Attribute 
+            => assembly.GetTypesWithAttribute<T>();
+
+        /// <summary>   
+        ///     Gets the derived types of a specified Attribute, within the assembly.
+        /// </summary>
+        /// <typeparam name="T">The type of class level attribute to scan for.</typeparam>
+        /// <param name="assembly">The assembly to scan.</param>
+        /// <returns>Returns an array of Types that are decorated with the specified class level attribute.</returns>
+        public static IEnumerable<(Type Type, T Attribute)> GetTypesWithAttribute<T>(this Assembly assembly)
+            where T : Attribute
+        {
+            return assembly.GetTypes()
+                .Where(type => type.GetCustomAttributes(typeof(T), false).Length > 0)
+                .Select(p => (p, (T)p.GetCustomAttribute(typeof(T), false)));
+        }
+    }
+}

--- a/CSharpHacks/CSharpHacks/StringHacks.cs
+++ b/CSharpHacks/CSharpHacks/StringHacks.cs
@@ -28,17 +28,240 @@ namespace CSharpHacks
                 : 0;
 
         public static IEnumerable<double> GetNumbers(this string @this) =>
-            Regex.Matches(@this, $@"-?\d+(\.\d+)?").Cast<Match>().Where(m => m.Success).Select(m => double.Parse(m.Value));
+            Regex.Matches(@this, @"-?\d+(\.\d+)?").Cast<Match>().Where(m => m.Success).Select(m => double.Parse(m.Value));
 
         public static string[] SplitOn(this string @this, string thingToSplitOn) =>
             @this.Split(new string[] { thingToSplitOn }, StringSplitOptions.RemoveEmptyEntries);
 
-        public static IEnumerable<T> ParseFromCsv<T>(this string @this, string lineSpltter, string fieldSplitter, Func<string[], T> converter) =>
-            @this.SplitOn(lineSpltter)
+        public static IEnumerable<T> ParseFromCsv<T>(this string @this, string lineSplitter, string fieldSplitter, Func<string[], T> converter) =>
+            @this.SplitOn(lineSplitter)
                 .Select(x => x.SplitOn(fieldSplitter))
-                .Select(x => converter(x));
+                .Select(converter);
 
         public static string ReplaceFirst(this string @this, string oldValue, string newValue) =>
             new Regex(Regex.Escape(oldValue)).Replace(@this, newValue, 1);
+
+
+        /// <summary>
+        ///     Returns a default string, if a specified string is <see langword="null" />,empty, or consists only of white-space characters.
+        /// </summary>
+        /// <param name="str">The string.</param>
+        /// <param name="defaultString">The default string.</param>
+        /// <returns>If the input string,<paramref name="str"/>, is null, empty, or whitespace, returns <paramref name="defaultString"/>, otherwise returns <paramref name="str"/>.</returns>
+        public static string IfNullOrWhitespace(this string str, string defaultString)
+        {
+            return string.IsNullOrWhiteSpace(str) ? defaultString : str;
+        }
+
+        /// <summary>
+        ///     Returns a default string, if a specified string is <see langword="null" />, or empty.
+        /// </summary>
+        /// <param name="str">The string.</param>
+        /// <param name="defaultString">The default string.</param>
+        /// <returns>If the input string,<paramref name="str"/>, is null or empty, returns <paramref name="defaultString"/>, otherwise returns <paramref name="str"/>.</returns>
+        public static string IfNullOrEmpty(this string str, string defaultString)
+        {
+            return string.IsNullOrEmpty(str) ? defaultString : str;
+        }
+
+        /// <summary>
+        ///     Converts a number to its ordinal numeral string representation.
+        /// </summary>
+        /// <param name="num">The number to convert.</param>
+        /// <returns>A string that represents the number, in ordinal numeral form.</returns>
+        public static string ToOrdinalNumeral(this int num)
+        {
+            return (num % 100) switch
+            {
+                11 => num.ToString("#,###0") + "th",
+                12 => num.ToString("#,###0") + "th",
+                13 => num.ToString("#,###0") + "th",
+                _ => (num % 10) switch
+                {
+                    1 => num.ToString("#,###0") + "st",
+                    2 => num.ToString("#,###0") + "nd",
+                    3 => num.ToString("#,###0") + "rd",
+                    _ => num.ToString("#,###0") + "th"
+                }
+            };
+        }
+
+        /// <summary>
+        ///     Determines whether a string contains any letters.
+        /// </summary>
+        /// <param name="input">the input string</param>
+        /// <returns><c>true</c> is the string contains letters [Aa..Zz]; otherwise <c>false</c>.</returns>
+        public static bool ContainsLetters(this string input)
+        {
+            return input?.Any(char.IsLetter) ?? false;
+        }
+
+        /// <summary>
+        ///     Determines whether a string contains any uppercase, or lowercase letters. Supports Unicode.
+        /// </summary>
+        /// <param name="input">the input string</param>
+        /// <returns><c>true</c> is the string contains letters [Aa..Zz]; otherwise <c>false</c>.</returns>
+        public static bool OnlyContainsLetters(this string input)
+        {
+            return input?.All(char.IsLetter) ?? false;
+        }
+
+        /// <summary>
+        ///     Determines whether a string contains any numbers. Supports Unicode.
+        /// </summary>
+        /// <param name="input">the input string</param>
+        /// <returns><c>true</c> is the string contains numbers [0..9]; otherwise <c>false</c>.</returns>
+        public static bool ContainsNumbers(this string input)
+        {
+            return input?.Any(char.IsNumber) ?? false;
+        }
+
+        /// <summary>
+        ///     Determines whether a string only contains any numbers. Supports Unicode.
+        /// </summary>
+        /// <param name="input">the input string</param>
+        /// <returns><c>true</c> is the string only contains numbers [0..9]; otherwise <c>false</c>.</returns>
+        public static bool OnlyContainsNumbers(this string input)
+        {
+            return input?.All(char.IsNumber) ?? false;
+        }
+
+        /// <summary>
+        ///    Strips out non-numeric characters in string, returning only digits. Supports Unicode.
+        ///    ref.: https://stackoverflow.com/questions/3977497/stripping-out-non-numeric-characters-in-string
+        /// </summary>
+        /// <param name="input">the input string</param>
+        /// <returns>the input string numeric part: for example, if input is "XYZ1234A5U6" it will return "123456"</returns>
+        public static string GetDigits(this string input)
+        {
+            return new string(input?.Where(char.IsDigit).ToArray());
+        }
+
+        /// <summary>
+        ///     Strips out numeric and special characters in string, returning only letters. Supports Unicode.
+        /// </summary>
+        /// <param name="input">the input string</param>
+        /// <returns>the letters contained within the input string: for example, if input is "XYZ1234A5U6~()" it will return "XYZAU"</returns>
+        public static string GetLetters(this string input)
+        {
+            return new string(input?.Where(char.IsLetter).ToArray());
+        }
+
+        /// <summary>
+        ///     Strips out any special characters in string, returning only letters and numbers. Supports Unicode.
+        /// </summary>
+        /// <param name="input">the input string</param>
+        /// <returns>the letters contained within the input string: for example, if input is "XYZ1234A5U6~()" it will return "XYZ1234A5U6"</returns>
+        public static string GetAlphaNumerics(this string input)
+        {
+            return new string(input?.Where(char.IsLetterOrDigit).ToArray());
+        }
+
+        /// <summary>
+        ///     Strips out any letters and numbers in string, returning only non-alpha-numeric characters. Supports Unicode.
+        /// </summary>
+        /// <param name="input">the input string</param>
+        /// <returns>the special characters contained within the input string: for example, if input is "XYZ1234A5U6~()" it will return "~()"</returns>
+        public static string GetNonAlphaNumerics(this string input)
+        {
+            return new string(input?.Where(c => !char.IsLetterOrDigit(c)).ToArray());
+        }
+
+        /// <summary>
+        ///     Splits a string into sentence form, from a pascal case word.
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <returns>Returns a <see cref="string"/>, where each word of the input string is separated by a space: for example, if input is "SplitPascalCase", it will return "Split Pascal Case".</returns>
+        public static string SplitPascalCase(this string input)
+        {
+            var words = Regex
+                .Matches(input, @"[A-Z]+(?=[A-Z][a-z]+)|\d|[A-Z][a-z]+")
+                .Cast<Match>()
+                .Select(m => m.Value)
+                .ToArray();
+            return string.Join(" ", words);
+        }
+
+        /// <summary>
+        ///     Appends a suffix to a string, if the suffix does not already appear at the end of the string.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="suffix">The suffix.</param>
+        /// <returns>A new <see cref="string"/> with the assured suffix.</returns>
+        public static string EnsureEndsWith(this string text, string suffix)
+        {
+            return text.EndsWith(suffix) ? text : $"{text}{suffix}";
+        }
+
+        /// <summary>
+        ///     Prepends a prefix to a string, if the prefix does not already appear at the start of the string.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="prefix">The prefix.</param>
+        /// <returns>A new <see cref="string"/> with the assured prefix.</returns>
+        public static string EnsureStartsWith(this string text, string prefix)
+        {
+            return text.StartsWith(prefix) ? text : $"{prefix}{text}";
+        }
+
+        /// <summary>
+        ///     Pluralises the specified string, based on a input value.
+        /// </summary>
+        /// <param name="singular">The singular.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="plural">The plural.</param>
+        /// <returns>Either the <paramref name="singular"/> value, or <paramref name="plural"/> value, based on whether <paramref name="value"/> is 1, or otherwise.</returns>
+        public static string Pluralise(this string singular, int value, string plural)
+        {
+            return Math.Abs(value) == 1 ? singular : plural;
+        }
+
+        /// <summary>
+        ///     Determines whether a string starts with any strings within a given set.
+        /// </summary>
+        /// <param name="this">The string to test.</param>
+        /// <param name="subStrings">The set of sub-strings to search for.</param>
+        /// <returns><c>true</c>, if the string does start with any of the sub-strings; otherwise, <c>false</c></returns>
+        public static bool StartsWithAnyOf(this string @this, IEnumerable<string> subStrings) => subStrings.Any(@this.StartsWith);
+
+        /// <summary>
+        ///     Determines whether a string starts with any strings within a given set.
+        /// </summary>
+        /// <param name="this">The string to test.</param>
+        /// <param name="subStrings">The set of sub-strings to search for.</param>
+        /// <returns><c>false</c>, if the string does start with any of the sub-strings; otherwise, <c>true</c></returns>
+        public static bool StartsWithNoneOf(this string @this, IEnumerable<string> subStrings) => !@this.StartsWithAnyOf(subStrings);
+
+        /// <summary>
+        ///     Determines whether a string contains any strings within a given set.
+        /// </summary>
+        /// <param name="this">The string to test.</param>
+        /// <param name="subStrings">The set of sub-strings to search for.</param>
+        /// <returns><c>true</c>, if the string contains any of the sub-strings; otherwise, <c>false</c></returns>
+        public static bool ContainsAnyOf(this string @this, IEnumerable<string> subStrings) => subStrings.Any(@this.Contains);
+
+        /// <summary>
+        ///     Determines whether a string contains any strings within a given set.
+        /// </summary>
+        /// <param name="this">The string to test.</param>
+        /// <param name="subStrings">The set of sub-strings to search for.</param>
+        /// <returns><c>false</c>, if the string contains any of the sub-strings; otherwise, <c>true</c></returns>
+        public static bool ContainsNoneOf(this string @this, IEnumerable<string> subStrings) => !@this.ContainsAnyOf(subStrings);
+
+        /// <summary>
+        ///     Determines whether a string ends with any strings within a given set.
+        /// </summary>
+        /// <param name="this">The string to test.</param>
+        /// <param name="subStrings">The set of sub-strings to search for.</param>
+        /// <returns><c>true</c>, if the string does end with any of the sub-strings; otherwise, <c>false</c></returns>
+        public static bool EndsWithAnyOf(this string @this, IEnumerable<string> subStrings) => subStrings.Any(@this.EndsWith);
+
+        /// <summary>
+        ///     Determines whether a string ends with any strings within a given set.
+        /// </summary>
+        /// <param name="this">The string to test.</param>
+        /// <param name="subStrings">The set of sub-strings to search for.</param>
+        /// <returns><c>false</c>, if the string does end with any of the sub-strings; otherwise, <c>true</c></returns>
+        public static bool EndsWithNoneOf(this string @this, IEnumerable<string> subStrings) => !@this.EndsWithAnyOf(subStrings);
     }
 }

--- a/CSharpHacks/CSharpHacks/TaskExtensions.cs
+++ b/CSharpHacks/CSharpHacks/TaskExtensions.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Threading.Tasks;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedType.Global
+
+namespace CSharpHacks
+{
+    // Accreditation: Theodor Zoulias - https://stackoverflow.com/a/60087110/2020124
+
+    /// <summary>
+    ///     Extension methods to aid working with Tasks.
+    /// </summary>
+    public static class TaskExtensions
+    {
+        /// <summary>
+        ///     Executes an action when a task has been completed successfully.
+        /// </summary>
+        /// <param name="task">The task to await the completion of.</param>
+        /// <param name="continuation">The action to perform after the task has completed.</param>
+        /// <param name="continueOnCapturedContext"><c>true</c> to attempt to marshall the continuation back to the original context captured, otherwise <c>false</c>.</param>
+        public static async Task OnCompletedSuccessfully(this Task task, Action continuation,
+            bool continueOnCapturedContext = true)
+        {
+            await task.ConfigureAwait(continueOnCapturedContext);
+            continuation();
+        }
+
+        /// <summary>
+        ///     Executes an action when a task has been completed successfully.
+        /// </summary>
+        /// <param name="task">The task to await the completion of.</param>
+        /// <param name="continuation">The function to perform after the task has completed.</param>
+        /// <param name="continueOnCapturedContext"><c>true</c> to attempt to marshall the continuation back to the original context captured, otherwise <c>false</c>.</param>
+        public static async Task OnCompletedSuccessfully(this Task task, Func<Task> continuation,
+            bool continueOnCapturedContext = true)
+        {
+            await task.ConfigureAwait(continueOnCapturedContext);
+            await continuation().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///     Executes an action when a task has been completed successfully.
+        /// </summary>
+        /// <param name="task">The task to await the completion of.</param>
+        /// <param name="continuation">The action to perform after the task has completed.</param>
+        /// <param name="continueOnCapturedContext"><c>true</c> to attempt to marshall the continuation back to the original context captured, otherwise <c>false</c>.</param>
+        public static async Task OnCompletedSuccessfully<TResult>(
+            this Task<TResult> task, Action<TResult> continuation,
+            bool continueOnCapturedContext = true)
+        {
+            var result = await task.ConfigureAwait(continueOnCapturedContext);
+            continuation(result);
+        }
+
+        /// <summary>
+        ///     Executes an action when a task has been completed successfully.
+        /// </summary>
+        /// <param name="task">The task to await the completion of.</param>
+        /// <param name="continuation">The function to perform after the task has completed.</param>
+        /// <param name="continueOnCapturedContext"><c>true</c> to attempt to marshall the continuation back to the original context captured, otherwise <c>false</c>.</param>
+        public static async Task OnCompletedSuccessfully<TResult>(
+            this Task<TResult> task, Func<TResult, Task> continuation,
+            bool continueOnCapturedContext = true)
+        {
+            var result = await task.ConfigureAwait(continueOnCapturedContext);
+            await continuation(result).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///     Executes an action when a task has been completed successfully.
+        /// </summary>
+        /// <param name="task">The task to await the completion of.</param>
+        /// <param name="continuation">The function to perform after the task has completed.</param>
+        /// <param name="continueOnCapturedContext"><c>true</c> to attempt to marshall the continuation back to the original context captured, otherwise <c>false</c>.</param>
+        public static async Task<TNewResult> OnCompletedSuccessfully<TResult, TNewResult>(
+            this Task<TResult> task, Func<TResult, TNewResult> continuation,
+            bool continueOnCapturedContext = true)
+        {
+            var result = await task.ConfigureAwait(continueOnCapturedContext);
+            return continuation(result);
+        }
+
+        /// <summary>
+        ///     Executes an action when a task has been completed successfully.
+        /// </summary>
+        /// <param name="task">The task to await the completion of.</param>
+        /// <param name="continuation">The function to perform after the task has completed.</param>
+        /// <param name="continueOnCapturedContext"><c>true</c> to attempt to marshall the continuation back to the original context captured, otherwise <c>false</c>.</param>
+        public static async Task<TNewResult> OnCompletedSuccessfully<TResult, TNewResult>(
+            this Task<TResult> task, Func<TResult, Task<TNewResult>> continuation,
+            bool continueOnCapturedContext = true)
+        {
+            var result = await task.ConfigureAwait(continueOnCapturedContext);
+            return await continuation(result).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
 - **CSharpHacks Project:**
     - **Update:** Target Framework updated to `netstandard2.0`. 
     - **Update:** C# Language Version updated to 10.0.
     - **Added:** InternalsVisibleTo attribute to allow CSharpHacks.Tests access to internal scope types and members.

 - **CSharpHacks.Tests Project:**
    - **Update:** Target Framework updated to `net7.0`. Support for `INumber<T>` for numerical test cases.
    - **Update:** C# Language Version updated to 10.0. 
    - **Update:** Updated Nuget package reference versions.
    - **Added:** Unit Tests for all added extension methods, below. 
    - **Added:** Mock objects for tests that need them. 
    - **Refactor:** Moved helper classes to sub-folder.

 - **ObjectHacks:** 
     - **Added:** `DynamicProperties.` Gets a dynamic collection of properties associated with an object instance, with a lifetime scoped to the lifetime of the object. 
     - **Added:** `To.` Directly casts the object instance to a specified type. 
     - **Added:** `As.` Safely casts the object instance to a specified type.

 - **TaskHacks:**
    - **Added:** `OnCompletedSuccessfully.` Executes an action when a task has been completed successfully.

 - **AssemblyExtensions:** 
     - **Added:** `GetAllTypesImplementingOpenGenericType.` Gets a collection of all types implementing a specified open generic interface, within a given assembly. 
     - **Added:** `InstantiateAllTypes.` Scans an assembly for all instantiable classes of a specified base class, and forms an array of instances. Note: Doesn't work with interfaces.

 - **NumericalExtensions:**
    - **Added:** `IsWithinRange.` Determines whether a value with within a given inclusive range.
    - **Added:** `IsGreaterThan.` Determines whether a value is greater than a given minimum value. 
    - **Added:** `IsLessThan.` Determines whether a value is less than a given maximum value. 
    - **Added:** `IsGreaterThanOrEqualTo.` Determines whether a value is greater than, or equal to, a given minimum value. 
    - **Added:** `IsLessThanOrEqualTo.` Determines whether a value is less than, or equal to, a given maximum value. 
    - **Added:** `FormatLargeNumber.` Formats the number in text form, with numerical group separators, for a given culture locale.

 - **EnumExtensions:** 
     - **Added:** `GetDescription.` Gets the description for the enum member, decorated with a `DescriptionAttribute`.

 - **EnumEx:**
    - **Added:** `Count.` Gets the number of values within this enum.

 - **EnumerableExtensions:** 
     - **Added:** `Random.` Chooses a value, at random, from a list of values. 
     - **Added:** `AddOrUpdate.` Adds a range of entries into a sorted dictionary. Includes a work around the fact that keys within Sorted Dictionaries cannot normally be overwritten. 
     - **Added:** `AddOrUpdateRange.` Adds a range of entries into a normal, or sorted dictionary. Includes a work around the fact that keys within Sorted Dictionaries cannot normally be overwritten. 
     - **Added:** `EnsureExistence.` If the value should exist, and it doesn't, it will be removed from the collection. If the value shouldn't exist, and it does, it will be removed from the collection. 
     - **Added:** `AddIfNotPresent.` Adds an item, if it not already present in the collection. 
     - **Added:** `RemoveIfPresent.` Removes an item, if it is already present in the collection. 
     - **Added:** `ContainsAny.` Determines whether the given collection contains any value within a given list of values. 
     - **Added:** `ContainsAnyKey.` Determines whether the given dictionary contains any key within a given list of keys. 
     - **Added:** `ContainsAnyValue.` Determines whether the given dictionary contains any value within a given list of values.

 - **ColourExtensions:**
    - **Added:** `UpdateColourChannel.` Updates a single colour channel within a `System.Drawing.Color` instance.
    - **Added:** `ToNormalisedRgba.` Normalises the specified colour. That being, it converts each channel value into a `double`, between 0.0 and 1.0, by dividing each value by `255d`. 
    - **Added:** `ToNormalisedArgb.` Normalises the specified colour. 
    - **Added:** `ToRgbaDoubleArray.` Converts a `Color` to an array of doubles, in RGBA order. 
    - **Added:** `ToArgbDoubleArray.` Converts a `Color` to an array of doubles, in ARGB order. 
    - **Added:** `ToRgbHexString.` Converts a `Color` to an RGB Hexadecimal string. 
    - **Added:** `ToArgbHexString.` Converts a `Color` to an ARGB Hexadecimal string. 
    - **Added:** `ToRgbaHexString.` Converts a `Color` to an RGBA Hexadecimal string. 
    - **Added:** `ToRgbString.` Converts a `Color` to an RGB() string.

 - **StringHacks:**
    - **Fixed:** Spelling mistakes within parameters, in various methods.
    - **Added:** `IfNullOrEmpty.` Returns a default string, if a specified string is null, or empty.
    - **Added:** `IfNullOrWhitespace.` Returns a default string, if a specified string is null, empty, or consists only of white-space characters.
    - **Added:** `ToOrdinalNumeral.` Converts a number to its ordinal numeral string representation. NOTE: Not localised.
    - **Added:** `ContainsLetters.` Determines whether a string contains any uppercase, or lowercase letters. Supports Unicode.
    - **Added:** `OnlyContainsLetters.` Determines whether a string contains any uppercase, or lowercase letters. Supports Unicode.
    - **Added:** `ContainsNumbers.` Determines whether a string contains any numbers. Supports Unicode.
    - **Added:** `ContainsOnlyNumbers.` Determines whether a string only contains any numbers. Supports Unicode.
    - **Added:** `GetDigits.` Strips out non-numeric characters in string, returning only digits. Supports Unicode.
    - **Added:** `GetLetters.` Strips out numeric and special characters in string, returning only letters. Supports Unicode.
    - **Added:** `GetAlphaNumerics.` Strips out any special characters in string, returning only letters and numbers. Supports Unicode.
    - **Added:** `GetNonAlphaNumerics.` Strips out any letters and numbers in string, returning only non-alpha-numeric characters. Supports Unicode.
    - **Added:** `SplitPascalCase.` Splits a string into sentence form, from a pascal case word.
    - **Added:** `EnsureEndsWith.` Appends a suffix to a string, if the suffix does not already appear at the end of the string.
    - **Added:** `EnsureStartsWith.` Prepends a prefix to a string, if the prefix does not already appear at the start of the string.
    - **Added:** `Pluralise.` Pluralises the specified string, based on a input value.
    - **Added:** `StartsWithAnyOf.` Determines whether a string starts with any strings within a given set.
    - **Added:** `StartsWithNoneOf.` Determines whether a string starts with any strings within a given set.
    - **Added:** `ContainsAnyOf.` Determines whether a string contains any strings within a given set.
    - **Added:** `ContainsNoneOf.` Determines whether a string contains any strings within a given set.
    - **Added:** `EndsWithAnyOf.` Determines whether a string ends with any strings within a given set.
    - **Added:** `EndsWithNoneOf.` Determines whether a string ends with any strings within a given set.